### PR TITLE
feat: 增加i18n provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,4 @@ yarn-error.log
 .yarn-integrity
 
 .tmp
-@antv/gatsby-theme-antv/components
+@antv/gatsby-theme-antv/lib

--- a/@antv/gatsby-theme-antv/package.json
+++ b/@antv/gatsby-theme-antv/package.json
@@ -87,7 +87,8 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "version": "git add package.json",
-    "compile:components": "rm -rf .tmp components && ../../node_modules/.bin/tsc --outDir .tmp --noEmit false -d && mv .tmp/@antv/gatsby-theme-antv/site/components components && cp site/components/*.less ./components",
+    "cp": "mkdir -p lib && cp -R .tmp/@antv/gatsby-theme-antv/site/components lib && cp site/components/*.less ./lib/components && cp site/common.json ./lib",
+    "compile:components": "rm -rf .tmp lib && ../../node_modules/.bin/tsc --outDir .tmp --noEmit false -d && npm run cp",
     "prepublishOnly": "npm run compile:components && np --yolo --no-publish",
     "test": "jest"
   },

--- a/@antv/gatsby-theme-antv/site/components/Header.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Header.tsx
@@ -131,6 +131,7 @@ const Header: React.FC<HeaderProps> = ({
                 onClick={e => {
                   e.preventDefault();
                   const value = lang === 'en' ? 'zh' : 'en';
+                  i18n.changeLanguage(value);
                   if (onLanguageChange) {
                     return onLanguageChange(value);
                   }

--- a/@antv/gatsby-theme-antv/site/components/withProvider.tsx
+++ b/@antv/gatsby-theme-antv/site/components/withProvider.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import i18next from 'i18next';
+import source from '../common.json';
+const i18n = i18next.createInstance();
+i18n
+  .use(initReactI18next) // passes i18n down to react-i18next
+  .init({
+    initImmediate: false,
+    resources: {
+      en: {
+        translation: { ...source },
+      },
+    },
+    fallbackLng: 'zh',
+    react: {
+      useSuspense: false,
+    },
+  });
+
+export default function witProvider<T>(
+  Element: React.ComponentType<T>,
+): React.ComponentType<T> {
+  return function(props) {
+    return (
+      <I18nextProvider i18n={i18n}>
+        <Element {...props} />
+      </I18nextProvider>
+    );
+  };
+}

--- a/@antv/gatsby-theme-antv/site/components/withProvider.tsx
+++ b/@antv/gatsby-theme-antv/site/components/withProvider.tsx
@@ -18,7 +18,7 @@ i18n
     },
   });
 
-export default function witProvider<T>(
+export default function withProvider<T>(
   Element: React.ComponentType<T>,
 ): React.ComponentType<T> {
   return function(props) {


### PR DESCRIPTION
增加 i18n provider

ChartCube 这种只引入 Header Footer的 需要用 withProvider包装一下

```js
import LHeader from '@antv/gatsby-theme-antv/lib/components/Header';
import LFooter from '@antv/gatsby-theme-antv/lib/components/Footer';
import withProivder from '@antv/gatsby-theme-antv/lib/components/withProvider';

const Header = withProivder(LHeader);
const Footer = withProivder(LFooter);
```