### PR TITLE
feat: Charts Gallary of examples

### DIFF
--- a/@antv/gatsby-theme-antv/gatsby-node.js
+++ b/@antv/gatsby-theme-antv/gatsby-node.js
@@ -305,6 +305,9 @@ exports.createPages = async ({ actions, graphql, reporter, store }) => {
         design,
         API,
       };
+      if (slug.includes('/examples/gallary')) {
+        context.allDemos = allDemos;
+      }
       const examplePosts = posts
         .filter(
           ({

--- a/@antv/gatsby-theme-antv/site/components/PlayGrounds.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGrounds.tsx
@@ -136,16 +136,18 @@ const PlayGrounds: React.FC<PlayGroundsProps> = ({
           })}
         </div>
       </div>
-      <PlayGround
-        key={currentExample.relativePath}
-        relativePath={currentExample.relativePath}
-        source={currentExample.source}
-        babeledSource={currentExample.babeledSource}
-        filename={currentExample.filename}
-        playground={playground}
-        location={location}
-        title={currentExample.title}
-      />
+      {playground && (
+        <PlayGround
+          key={currentExample.relativePath}
+          relativePath={currentExample.relativePath}
+          source={currentExample.source}
+          babeledSource={currentExample.babeledSource}
+          filename={currentExample.filename}
+          playground={playground}
+          location={location}
+          title={currentExample.title}
+        />
+      )}
     </div>
   );
 };

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -264,8 +264,6 @@ export default function Template({
     return demo.postFrontmatter[i18n.language].title;
   });
 
-  console.log(allDemosInCategory);
-
   const gallaryPageContent = (
     <>
       <h1>{frontmatter.title}</h1>
@@ -281,11 +279,14 @@ export default function Template({
           if (b === 'OTHER') {
             return 1;
           }
-          return 0;
+          return (
+            allDemosInCategory[a][0].postFrontmatter[i18n.language].order -
+            allDemosInCategory[b][0].postFrontmatter[i18n.language].order
+          );
         })
         .map((category: string) => (
           <div key={category}>
-            {category !== 'OTHER' && <h3>{category}</h3>}
+            {category !== 'OTHER' && <h2>{category}</h2>}
             <ul className={styles.gallery}>
               {allDemosInCategory[category].map(demo => {
                 const cardTitle = demo.title

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -103,6 +103,7 @@ export default function Template({
     prev: any;
     next: any;
     exampleSections: any;
+    allDemos?: any[];
   };
 }) {
   const { allMarkdownRemark, site } = data; // data.markdownRemark holds our post data
@@ -174,7 +175,7 @@ export default function Template({
     activeTab = 'design';
     exampleRootSlug = exampleRootSlug.replace(/\/design$/, '');
   }
-  const { exampleSections = {}, prev, next } = pageContext;
+  const { exampleSections = {}, prev, next, allDemos = [] } = pageContext;
 
   const menu = (
     <Menu
@@ -256,6 +257,8 @@ export default function Template({
     </Drawer>
   );
 
+  console.log(allDemos);
+
   const gallaryPageContent = (
     <>
       <h1>{frontmatter.title}</h1>
@@ -263,7 +266,7 @@ export default function Template({
         /* eslint-disable-next-line react/no-danger */
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      图表
+      <PlayGrounds examples={allDemos} location={location} />
     </>
   );
 

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -257,7 +257,7 @@ export default function Template({
     </Drawer>
   );
 
-  const allDemosInCategory = groupBy(allDemos, demo => {
+  const allDemosInCategory = groupBy(allDemos || [], demo => {
     if (!demo.postFrontmatter || !demo.postFrontmatter[i18n.language]) {
       return 'OTHER';
     }

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -257,6 +257,15 @@ export default function Template({
     </Drawer>
   );
 
+  const allDemosInCategory = groupBy(allDemos, demo => {
+    if (!demo.postFrontmatter || !demo.postFrontmatter[i18n.language]) {
+      return 'OTHER';
+    }
+    return demo.postFrontmatter[i18n.language].title;
+  });
+
+  console.log(allDemosInCategory);
+
   const gallaryPageContent = (
     <>
       <h1>{frontmatter.title}</h1>
@@ -264,36 +273,51 @@ export default function Template({
         /* eslint-disable-next-line react/no-danger */
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      <ul className={styles.gallery}>
-        {allDemos.map(demo => {
-          const cardTitle = demo.title
-            ? demo.title[i18n.language]
-            : demo.filename;
-          const demoSlug = demo.relativePath.replace(
-            /\/demo\/(.*)\..*/,
-            (_: string, filename: string) => {
-              return `#${filename}`;
-            },
-          );
-          return (
-            <li className={styles.galleryCard} key={demo.relativePath}>
-              <Link
-                to={`${i18n.language}/examples/${demoSlug}`}
-                className={styles.galleryCardLink}
-              >
-                <img
-                  src={
-                    demo.screenshot ||
-                    'https://gw.alipayobjects.com/os/s/prod/antv/assets/image/screenshot-placeholder-b8e70.png'
-                  }
-                  alt={cardTitle}
-                />
-                <h4>{cardTitle}</h4>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
+      {Object.keys(allDemosInCategory)
+        .sort((a: string, b: string) => {
+          if (a === 'OTHER') {
+            return -1;
+          }
+          if (b === 'OTHER') {
+            return 1;
+          }
+          return 0;
+        })
+        .map((category: string) => (
+          <div key={category}>
+            {category !== 'OTHER' && <h3>{category}</h3>}
+            <ul className={styles.gallery}>
+              {allDemosInCategory[category].map(demo => {
+                const cardTitle = demo.title
+                  ? demo.title[i18n.language]
+                  : demo.filename;
+                const demoSlug = demo.relativePath.replace(
+                  /\/demo\/(.*)\..*/,
+                  (_: string, filename: string) => {
+                    return `#${filename}`;
+                  },
+                );
+                return (
+                  <li className={styles.galleryCard} key={demo.relativePath}>
+                    <Link
+                      to={`${i18n.language}/examples/${demoSlug}`}
+                      className={styles.galleryCardLink}
+                    >
+                      <img
+                        src={
+                          demo.screenshot ||
+                          'https://gw.alipayobjects.com/os/s/prod/antv/assets/image/screenshot-placeholder-b8e70.png'
+                        }
+                        alt={cardTitle}
+                      />
+                      <h4>{cardTitle}</h4>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
     </>
   );
 

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -256,6 +256,81 @@ export default function Template({
     </Drawer>
   );
 
+  const gallaryPageContent = (
+    <>
+      <h1>{frontmatter.title}</h1>
+      <div
+        /* eslint-disable-next-line react/no-danger */
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      图表
+    </>
+  );
+
+  const exmaplePageContent = (
+    <>
+      <h1>
+        {frontmatter.title}
+        <Tooltip title={t('在 GitHub 上编辑')}>
+          <a
+            href={`${githubUrl}/edit/master/examples/${relativePath}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.editOnGtiHubButton}
+          >
+            <Icon type="edit" />
+          </a>
+        </Tooltip>
+      </h1>
+      <div
+        /* eslint-disable-next-line react/no-danger */
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <Tabs
+        slug={exampleRootSlug}
+        active={activeTab}
+        showTabs={{
+          examples:
+            exampleSections.examples && exampleSections.examples.length > 0,
+          API: !!exampleSections.API,
+          design: !!exampleSections.design,
+        }}
+        examplesCount={(exampleSections.examples || []).length}
+      />
+      {exampleSections.examples && (
+        <div style={{ display: activeTab === 'examples' ? 'block' : 'none' }}>
+          <PlayGrounds
+            examples={exampleSections.examples}
+            location={location}
+            playground={playground || {}}
+          />
+        </div>
+      )}
+      {exampleSections.API && (
+        <div
+          style={{ display: activeTab === 'API' ? 'block' : 'none' }}
+          /* eslint-disable-next-line react/no-danger */
+          dangerouslySetInnerHTML={{
+            __html: exampleSections.API.node.html,
+          }}
+        />
+      )}
+      {exampleSections.design && (
+        <div
+          style={{ display: activeTab === 'design' ? 'block' : 'none' }}
+          /* eslint-disable-next-line react/no-danger */
+          dangerouslySetInnerHTML={{
+            __html: exampleSections.design.node.html,
+          }}
+        />
+      )}
+      <div>
+        <NavigatorBanner type="prev" post={prev} />
+        <NavigatorBanner type="next" post={next} />
+      </div>
+    </>
+  );
+
   return (
     <>
       <SEO title={frontmatter.title} lang={i18n.language} />
@@ -267,68 +342,9 @@ export default function Template({
         {menuSider}
         <Article className={styles.markdown}>
           <div className={styles.main} style={{ width: '100%' }}>
-            <h1>
-              {frontmatter.title}
-              <Tooltip title={t('在 GitHub 上编辑')}>
-                <a
-                  href={`${githubUrl}/edit/master/examples/${relativePath}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles.editOnGtiHubButton}
-                >
-                  <Icon type="edit" />
-                </a>
-              </Tooltip>
-            </h1>
-            <div
-              /* eslint-disable-next-line react/no-danger */
-              dangerouslySetInnerHTML={{ __html: html }}
-            />
-            <Tabs
-              slug={exampleRootSlug}
-              active={activeTab}
-              showTabs={{
-                examples:
-                  exampleSections.examples &&
-                  exampleSections.examples.length > 0,
-                API: !!exampleSections.API,
-                design: !!exampleSections.design,
-              }}
-              examplesCount={(exampleSections.examples || []).length}
-            />
-            {exampleSections.examples && (
-              <div
-                style={{ display: activeTab === 'examples' ? 'block' : 'none' }}
-              >
-                <PlayGrounds
-                  examples={exampleSections.examples}
-                  location={location}
-                  playground={playground || {}}
-                />
-              </div>
-            )}
-            {exampleSections.API && (
-              <div
-                style={{ display: activeTab === 'API' ? 'block' : 'none' }}
-                /* eslint-disable-next-line react/no-danger */
-                dangerouslySetInnerHTML={{
-                  __html: exampleSections.API.node.html,
-                }}
-              />
-            )}
-            {exampleSections.design && (
-              <div
-                style={{ display: activeTab === 'design' ? 'block' : 'none' }}
-                /* eslint-disable-next-line react/no-danger */
-                dangerouslySetInnerHTML={{
-                  __html: exampleSections.design.node.html,
-                }}
-              />
-            )}
-            <div>
-              <NavigatorBanner type="prev" post={prev} />
-              <NavigatorBanner type="next" post={next} />
-            </div>
+            {pathWithoutTrailingSlashes.includes('/examples/gallary')
+              ? gallaryPageContent
+              : exmaplePageContent}
           </div>
         </Article>
       </AntLayout>

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -257,8 +257,6 @@ export default function Template({
     </Drawer>
   );
 
-  console.log(allDemos);
-
   const gallaryPageContent = (
     <>
       <h1>{frontmatter.title}</h1>
@@ -266,7 +264,36 @@ export default function Template({
         /* eslint-disable-next-line react/no-danger */
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      <PlayGrounds examples={allDemos} location={location} />
+      <ul className={styles.gallery}>
+        {allDemos.map(demo => {
+          const cardTitle = demo.title
+            ? demo.title[i18n.language]
+            : demo.filename;
+          const demoSlug = demo.relativePath.replace(
+            /\/demo\/(.*)\..*/,
+            (_: string, filename: string) => {
+              return `#${filename}`;
+            },
+          );
+          return (
+            <li className={styles.galleryCard} key={demo.relativePath}>
+              <Link
+                to={`${i18n.language}/examples/${demoSlug}`}
+                className={styles.galleryCardLink}
+              >
+                <img
+                  src={
+                    demo.screenshot ||
+                    'https://gw.alipayobjects.com/os/s/prod/antv/assets/image/screenshot-placeholder-b8e70.png'
+                  }
+                  alt={cardTitle}
+                />
+                <h4>{cardTitle}</h4>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
     </>
   );
 

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -226,6 +226,64 @@
   }
 }
 
+.gallery {
+  list-style: none;
+  margin: 0 -16px !important;
+
+  .galleryCard {
+    display: inline-block;
+    width: 33.33%;
+    margin: 16px 0;
+    padding: 0;
+
+    .galleryCardLink {
+      display: block;
+      position: relative;
+      margin: 0 16px;
+      cursor: pointer;
+      border: 1px solid @border-color-split;
+      transition: all 0.3s;
+      border-radius: 4px;
+      overflow: hidden;
+
+      img {
+        width: 100%;
+        height: calc(100vw / 7 - 10px);
+        min-height: 180px;
+        max-height: 280px;
+        object-fit: cover;
+      }
+
+      h4 {
+        margin: 0;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        transition: all 0.3s;
+        text-align: center;
+        line-height: 230px;
+        font-size: 20px;
+        transform: translateY(4px);
+        text-shadow: 0 3px 16px rgba(0, 0, 0, .1);
+      }
+
+      &:hover {
+        border-color: fade(@primary-color, 80%);
+
+        h4 {
+          display: block;
+          opacity: 1;
+          background: fade(@primary-color, 10%);
+          transform: translateY(0);
+        }
+      }
+    }
+  }
+}
+
 @media only screen and (max-width: 991.99px) {
   .markdown {
     .main {
@@ -240,6 +298,12 @@
 
   .sider {
     width: 240px !important;
+  }
+
+  .gallery {
+    .galleryCard {
+      width: 50%;
+    }
   }
 }
 
@@ -256,5 +320,10 @@
   }
   .main {
     margin-top: 30px;
+  }
+  .gallery {
+    .galleryCard {
+      width: 100%;
+    }
   }
 }

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -232,14 +232,14 @@
 
   .galleryCard {
     display: inline-block;
-    width: 33.33%;
-    margin: 16px 0;
+    width: 25%;
+    margin: 12px 0;
     padding: 0;
 
     .galleryCardLink {
       display: block;
       position: relative;
-      margin: 0 16px;
+      margin: 0 12px;
       cursor: pointer;
       border: 1px solid @border-color-split;
       transition: all 0.3s;
@@ -248,8 +248,8 @@
 
       img {
         width: 100%;
-        height: calc(100vw / 7 - 10px);
-        min-height: 180px;
+        height: calc(100vw / 8 - 20px);
+        min-height: 160px;
         max-height: 280px;
         object-fit: cover;
       }
@@ -264,17 +264,19 @@
         opacity: 0;
         transition: all 0.3s;
         text-align: center;
-        line-height: 230px;
         font-size: 20px;
+        display: flex;
+        text-align: center;
+        align-items: center;
+        justify-content: center;
         transform: translateY(4px);
-        text-shadow: 0 3px 16px rgba(0, 0, 0, .1);
+        text-shadow: 0 3px 16px rgba(0, 0, 0, 0.1);
       }
 
       &:hover {
         border-color: fade(@primary-color, 80%);
 
         h4 {
-          display: block;
           opacity: 1;
           background: fade(@primary-color, 10%);
           transform: translateY(0);
@@ -284,12 +286,20 @@
   }
 }
 
+@media only screen and (max-width: 1199.99px) {
+  .gallery {
+    .galleryCard {
+      width: 33.3%;
+    }
+  }
+}
+
 @media only screen and (max-width: 991.99px) {
   .markdown {
     .main {
       width: 100%;
-      padding-left: 16px;
-      padding-right: 16px;
+      padding-left: 32px;
+      padding-right: 32px;
     }
     .toc {
       display: none;
@@ -320,7 +330,12 @@
   }
   .main {
     margin-top: 30px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
+}
+
+@media only screen and (max-width: 575.99px) {
   .gallery {
     .galleryCard {
       width: 100%;

--- a/example/examples/basic/index.en.md
+++ b/example/examples/basic/index.en.md
@@ -2,8 +2,6 @@
 title: Component
 order: 0
 icon: column
-redirect_from:
-  - /en/examples
 ---
 
 Description about this component.

--- a/example/examples/basic/index.zh.md
+++ b/example/examples/basic/index.zh.md
@@ -2,8 +2,6 @@
 title: 图表演示
 order: 0
 icon: column
-redirect_from:
-  - /zh/examples
 ---
 
 图表的基本描述。

--- a/example/examples/gallary/index.en.md
+++ b/example/examples/gallary/index.en.md
@@ -1,0 +1,5 @@
+---
+title: Gallary
+order: -1
+icon: other
+---

--- a/example/examples/gallary/index.zh.md
+++ b/example/examples/gallary/index.zh.md
@@ -1,0 +1,5 @@
+---
+title: 所有图表
+order: -1
+icon: other
+---

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -28,7 +28,7 @@ module.exports = {
         },
       },
       {
-        slug: 'examples',
+        slug: 'examples/gallary',
         title: {
           zh: '图表演示',
           en: 'Examples',


### PR DESCRIPTION
演示支持所有图表页面（Gallary）。

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/507615/71402479-f446f780-2667-11ea-9573-91836c2bf19e.png">

添加办法如下：

1. 升级 `@antv/gatsby-theme-antv` 到 `0.10.26` 版本以上。
2. 在 `examples` 目录下添加 gallary 文件夹和两个 md 文件，内容照抄[这里](https://github.com/antvis/gatsby-theme-antv/tree/683f43c13110782f3e65c199a3bc9bef22c343f3/example/examples/gallary)。
3. 修改顶部导航的链接 `slug` 为 `examples/gallary`，去除演示里相关的 `redirect_from` 属性：https://github.com/antvis/gatsby-theme-antv/commit/5f13ce74287ba435b9b8cae65b00d32527e4d55f

有问题请联系 @afc163
