### PR TITLE
feat: support display data with http request in demo

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
@@ -142,8 +142,7 @@ const PlayGround: React.FC<PlayGroundProps> = ({
     const dataFileMatch = currentSourceCode.match(/fetch\('(.*)'\)/);
     if (
       dataFileMatch &&
-      dataFileMatch.length > 0 &&
-      !dataFileMatch[1].startsWith('http')
+      dataFileMatch.length > 0
     ) {
       fetch(dataFileMatch[1])
         .then(response => response.json())


### PR DESCRIPTION
The URL of the fetch is the online address, and you can still view the data