### PR TITLE
fix: make the left sidebar menu full height & stick to the viewport

### DIFF
--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -201,7 +201,9 @@ const Layout: React.FC<LayoutProps> = ({ children, location }) => {
         {...logoProps}
       />
       <main className={styles.main}>{children}</main>
-      <Footer githubUrl={githubUrl} rootDomain="https://antv.vision" />
+      {isHomePage && (
+        <Footer githubUrl={githubUrl} rootDomain="https://antv.vision" />
+      )}
     </>
   );
 };

--- a/@antv/gatsby-theme-antv/site/templates/document.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/document.tsx
@@ -15,6 +15,7 @@ import Swatch from '../components/Swatch';
 import Article from '../components/Article';
 import ReadingTime from '../components/ReadingTime';
 import NavigatorBanner from '../components/NavigatorBanner';
+import Footer from '../components/Footer';
 import SEO from '../components/Seo';
 import { usePrevAndNext } from '../hooks';
 import { capitalize } from '../utils';
@@ -212,7 +213,7 @@ export default function Template({
     <Menu
       mode="inline"
       selectedKeys={[slug]}
-      style={{ height: '100%' }}
+      className={styles.menu}
       openKeys={openKeys}
       onOpenChange={(currentOpenKeys) =>
         setOpenKeys(currentOpenKeys as string[])
@@ -227,9 +228,11 @@ export default function Template({
   const isWide = useMedia('(min-width: 767.99px)', true);
   const [drawOpen, setDrawOpen] = useState(false);
   const menuSider = isWide ? (
-    <AntLayout.Sider width="auto" theme="light" className={styles.sider}>
-      {menu}
-    </AntLayout.Sider>
+    <Affix offsetTop={0}>
+      <AntLayout.Sider width="auto" theme="light" className={styles.sider}>
+        {menu}
+      </AntLayout.Sider>
+    </Affix>
   ) : (
     <Drawer
       handler={
@@ -263,44 +266,47 @@ export default function Template({
         className={styles.layout}
       >
         {menuSider}
-        <Article className={styles.markdown}>
-          <Affix offsetTop={8}>
-            <div
-              className={styles.toc}
-              /* eslint-disable-next-line react/no-danger */
-              dangerouslySetInnerHTML={{
-                __html: parseTableOfContents(tableOfContents),
-              }}
-            />
-          </Affix>
-          <div className={styles.main}>
-            <h1>
-              {frontmatter.title}
-              <Tooltip title={t('在 GitHub 上编辑')}>
-                <a
-                  href={getGithubSourceUrl({
-                    githubUrl,
-                    relativePath,
-                    prefix: 'docs',
-                  })}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={styles.editOnGtiHubButton}
-                >
-                  <EditOutlined />
-                </a>
-              </Tooltip>
-            </h1>
-            <div className={styles.meta}>
-              <ReadingTime readingTime={readingTime} />
+        <AntLayout style={{ background: '#fff' }}>
+          <Article className={styles.markdown}>
+            <Affix offsetTop={8}>
+              <div
+                className={styles.toc}
+                /* eslint-disable-next-line react/no-danger */
+                dangerouslySetInnerHTML={{
+                  __html: parseTableOfContents(tableOfContents),
+                }}
+              />
+            </Affix>
+            <div className={styles.main}>
+              <h1>
+                {frontmatter.title}
+                <Tooltip title={t('在 GitHub 上编辑')}>
+                  <a
+                    href={getGithubSourceUrl({
+                      githubUrl,
+                      relativePath,
+                      prefix: 'docs',
+                    })}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.editOnGtiHubButton}
+                  >
+                    <EditOutlined />
+                  </a>
+                </Tooltip>
+              </h1>
+              <div className={styles.meta}>
+                <ReadingTime readingTime={readingTime} />
+              </div>
+              <div className={styles.content}>{renderAst(htmlAst)}</div>
+              <div>
+                <NavigatorBanner type="prev" post={prev} />
+                <NavigatorBanner type="next" post={next} />
+              </div>
             </div>
-            <div className={styles.content}>{renderAst(htmlAst)}</div>
-            <div>
-              <NavigatorBanner type="prev" post={prev} />
-              <NavigatorBanner type="next" post={next} />
-            </div>
-          </div>
-        </Article>
+          </Article>
+          <Footer githubUrl={githubUrl} rootDomain="https://antv.vision" />
+        </AntLayout>
       </AntLayout>
     </>
   );

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { graphql, Link } from 'gatsby';
-import { Layout as AntLayout, Menu, Tooltip, Anchor } from 'antd';
+import { Layout as AntLayout, Menu, Tooltip, Anchor, Affix } from 'antd';
 import {
   createFromIconfontCN,
   EditOutlined,
@@ -17,6 +17,7 @@ import SEO from '../components/Seo';
 import Tabs from '../components/Tabs';
 import PlayGrounds from '../components/PlayGrounds';
 import NavigatorBanner from '../components/NavigatorBanner';
+import Footer from '../components/Footer';
 import { capitalize } from '../utils';
 import { usePrevAndNext } from '../hooks';
 import { getGithubSourceUrl } from './document';
@@ -184,7 +185,7 @@ export default function Template({
     <Menu
       mode="inline"
       selectedKeys={[slug]}
-      style={{ height: '100%' }}
+      className={styles.menu}
       openKeys={openKeys}
       onOpenChange={(currentOpenKeys) =>
         setOpenKeys(currentOpenKeys as string[])
@@ -243,9 +244,11 @@ export default function Template({
   const isWide = useMedia('(min-width: 767.99px)', true);
   const [drawOpen, setDrawOpen] = useState(false);
   const menuSider = isWide ? (
-    <AntLayout.Sider width="auto" theme="light" className={styles.sider}>
-      {menu}
-    </AntLayout.Sider>
+    <Affix offsetTop={0}>
+      <AntLayout.Sider width="auto" theme="light" className={styles.sider}>
+        {menu}
+      </AntLayout.Sider>
+    </Affix>
   ) : (
     <Drawer
       handler={
@@ -425,17 +428,20 @@ export default function Template({
         className={styles.layout}
       >
         {menuSider}
-        <Article className={styles.markdown}>
-          <div className={styles.main} style={{ width: '100%' }}>
-            {pathWithoutTrailingSlashes.endsWith('/examples/gallery')
-              ? galleryPageContent
-              : exmaplePageContent}
-            <div>
-              <NavigatorBanner type="prev" post={prev} />
-              <NavigatorBanner type="next" post={next} />
+        <AntLayout style={{ background: '#fff' }}>
+          <Article className={styles.markdown}>
+            <div className={styles.main} style={{ width: '100%' }}>
+              {pathWithoutTrailingSlashes.endsWith('/examples/gallery')
+                ? galleryPageContent
+                : exmaplePageContent}
+              <div>
+                <NavigatorBanner type="prev" post={prev} />
+                <NavigatorBanner type="next" post={next} />
+              </div>
             </div>
-          </div>
-        </Article>
+          </Article>
+          <Footer githubUrl={githubUrl} rootDomain="https://antv.vision" />
+        </AntLayout>
       </AntLayout>
     </>
   );

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -142,7 +142,7 @@
 }
 
 .layout {
-  margin: 24px 0 32px 0;
+  margin-top: 24px;
 }
 
 .editOnGtiHubButton {
@@ -156,6 +156,7 @@
 
 .main {
   width: calc(100% - 160px);
+  margin-bottom: 32px;
   padding-left: 48px;
   padding-right: 24px;
   overflow: hidden;
@@ -209,6 +210,13 @@
 
 .sider {
   width: 280px !important;
+  height: 100vh;
+}
+
+.menu {
+  height: 100vh;
+  padding-bottom: 48px;
+  overflow: auto;
 }
 
 .menuIcon {


### PR DESCRIPTION
固定左边侧边栏目录，侧边栏和内容区分开滚动。
原来：
![doc-sider-ori](https://user-images.githubusercontent.com/16997933/89483636-1c3a3400-d7cf-11ea-828f-0b5f6a3f73b9.gif)

固定：
![doc-sider](https://user-images.githubusercontent.com/16997933/89483677-31af5e00-d7cf-11ea-9814-7bdd9ec89516.gif)
