### PR TITLE
fix: improve docsearch result

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/Tabs.module.less
+++ b/@antv/gatsby-theme-antv/site/components/Tabs.module.less
@@ -85,4 +85,8 @@ ul.tabs {
       right: -16px;
     }
   }
+
+  .hidden {
+    display: none;
+  }
 }

--- a/@antv/gatsby-theme-antv/site/components/Tabs.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Tabs.tsx
@@ -15,11 +15,21 @@ const Tabs: React.FC<{
   slug: string;
   showTabs: ShowTabsProps;
   examplesCount?: number;
-}> = ({ active, slug, showTabs = {} as ShowTabsProps, examplesCount }) => {
+  title?: string;
+}> = ({
+  active,
+  slug,
+  showTabs = {} as ShowTabsProps,
+  examplesCount,
+  title,
+}) => {
   const { t } = useTranslation();
   if (showTabs.API === false && showTabs.design === false) {
     return <h3 className={styles.title}>{t('演示')}</h3>;
   }
+  const hiddenTitleForDocsearch = (
+    <span className={styles.hidden}>{title} - </span>
+  );
   return (
     <ul className={styles.tabs}>
       <li
@@ -30,6 +40,7 @@ const Tabs: React.FC<{
       >
         <Link to={slug}>
           <h2>
+            {hiddenTitleForDocsearch}
             {t('代码演示')}
             {examplesCount && examplesCount > 1 ? (
               <sup className={styles.count}>({examplesCount})</sup>
@@ -44,7 +55,10 @@ const Tabs: React.FC<{
         })}
       >
         <Link to={`${slug}/API`}>
-          <h2>API</h2>
+          <h2>
+            {hiddenTitleForDocsearch}
+            API
+          </h2>
         </Link>
       </li>
       <li
@@ -54,7 +68,10 @@ const Tabs: React.FC<{
         })}
       >
         <Link to={`${slug}/design`}>
-          <h2>{t('设计指引')}</h2>
+          <h2>
+            {hiddenTitleForDocsearch}
+            {t('设计指引')}
+          </h2>
         </Link>
       </li>
     </ul>

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -377,6 +377,7 @@ export default function Template({
       <div>{renderAst(htmlAst)}</div>
       <Tabs
         slug={exampleRootSlug}
+        title={frontmatter.title}
         active={activeTab}
         showTabs={{
           examples:

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -386,33 +386,29 @@ export default function Template({
         }}
         examplesCount={(exampleSections.examples || []).length}
       />
-      {exampleSections.examples && (
-        <div style={{ display: activeTab === 'examples' ? 'block' : 'none' }}>
-          <PlayGrounds
-            examples={exampleSections.examples}
-            location={location}
-            playground={playground || {}}
-          />
-        </div>
-      )}
-      {exampleSections.API && (
+      {exampleSections.examples && activeTab === 'examples' ? (
+        <PlayGrounds
+          examples={exampleSections.examples}
+          location={location}
+          playground={playground || {}}
+        />
+      ) : null}
+      {exampleSections.API && activeTab === 'API' ? (
         <div
-          style={{ display: activeTab === 'API' ? 'block' : 'none' }}
           /* eslint-disable-next-line react/no-danger */
           dangerouslySetInnerHTML={{
             __html: exampleSections.API.node.html,
           }}
         />
-      )}
-      {exampleSections.design && (
+      ) : null}
+      {exampleSections.design && activeTab === 'design' ? (
         <div
-          style={{ display: activeTab === 'design' ? 'block' : 'none' }}
           /* eslint-disable-next-line react/no-danger */
           dangerouslySetInnerHTML={{
             __html: exampleSections.design.node.html,
           }}
         />
-      )}
+      ) : null}
     </>
   );
 


### PR DESCRIPTION
close #207 

- [x] example 页面内容不在当前 tab 不渲染出来，避免污染搜索结果
- [x] example 页面 tab 前添加看不见的 title，优化搜索结果展示