### PR TITLE
fix issue of document template menu and tabOfContent

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/Footer.module.less
+++ b/@antv/gatsby-theme-antv/site/components/Footer.module.less
@@ -4,9 +4,6 @@
 .footer {
   font-family: Avenir, @font-family;
 
-  // 保证 footer 不被遮挡
-  z-index: 99;
-
   :global(.rc-footer-container),
   :global(.rc-footer-bottom-container) {
     .container1440;
@@ -36,5 +33,21 @@
     .bottom {
       display: block;
     }
+  }
+}
+
+.asideMenu {
+  margin-left: 0px;
+}
+
+@media only screen and (min-width: 767.99px) {
+  .asideMenu {
+    margin-left: 240px;
+  }
+}
+
+@media only screen and (min-width: 991.99px) {
+  .asideMenu {
+    margin-left: 280px;
   }
 }

--- a/@antv/gatsby-theme-antv/site/components/Footer.module.less
+++ b/@antv/gatsby-theme-antv/site/components/Footer.module.less
@@ -4,6 +4,9 @@
 .footer {
   font-family: Avenir, @font-family;
 
+  // 保证 footer 不被遮挡
+  z-index: 99;
+
   :global(.rc-footer-container),
   :global(.rc-footer-bottom-container) {
     .container1440;

--- a/@antv/gatsby-theme-antv/site/components/Footer.module.less
+++ b/@antv/gatsby-theme-antv/site/components/Footer.module.less
@@ -36,18 +36,18 @@
   }
 }
 
-.asideMenu {
+.withMenu {
   margin-left: 0px;
 }
 
 @media only screen and (min-width: 767.99px) {
-  .asideMenu {
+  .withMenu {
     margin-left: 240px;
   }
 }
 
 @media only screen and (min-width: 991.99px) {
-  .asideMenu {
+  .withMenu {
     margin-left: 280px;
   }
 }

--- a/@antv/gatsby-theme-antv/site/components/Footer.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withPrefix } from 'gatsby';
 import { default as RCFooter, FooterProps as RcFooterProps } from 'rc-footer';
 import { useTranslation } from 'react-i18next';
 import {
@@ -6,6 +7,7 @@ import {
   WeiboOutlined,
   ZhihuOutlined,
 } from '@ant-design/icons';
+import classnames from 'classnames';
 import { getProducts } from './getProducts';
 import { useChinaMirrorHost } from '../hooks';
 import styles from './Footer.module.less';
@@ -18,6 +20,7 @@ interface FooterProps extends RcFooterProps {
   language?: string;
   githubUrl?: string;
   footerProps?: object;
+  location: Location;
 }
 
 const Footer: React.FC<FooterProps> = ({
@@ -27,6 +30,7 @@ const Footer: React.FC<FooterProps> = ({
   language,
   rootDomain = '',
   footerProps,
+  location,
 }) => {
   const { t, i18n } = useTranslation();
   const lang = language || i18n.language;
@@ -133,12 +137,21 @@ const Footer: React.FC<FooterProps> = ({
       items: product.links,
     }));
 
+  // 通过 location 判断是否加载 example or document template
+  const pathPrefix = withPrefix('/').replace(/\/$/, '');
+  const path = location.pathname.replace(pathPrefix, '');
+  const isGallery =
+    path.startsWith(`/zh/examples`) || path.startsWith(`/en/examples`);
+  const isDocs = path.startsWith(`/zh/docs`) || path.startsWith(`/en/docs`);
+
   return (
     <RCFooter
       maxColumnsPerRow={4}
       theme={theme}
       columns={columns || [...defaultColumns, more]}
-      className={styles.footer}
+      className={classnames(styles.footer, {
+        [styles.asideMenu]: isGallery || isDocs,
+      })}
       bottom={
         bottom || (
           <div className={styles.bottom}>

--- a/@antv/gatsby-theme-antv/site/components/Footer.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Footer.tsx
@@ -137,12 +137,13 @@ const Footer: React.FC<FooterProps> = ({
       items: product.links,
     }));
 
-  // 通过 location 判断是否加载 example or document template
+  // 有 menu 的模版 footer 表现不同，通过 location 判断加载的模版
   const pathPrefix = withPrefix('/').replace(/\/$/, '');
   const path = location.pathname.replace(pathPrefix, '');
-  const isGallery =
+  const isExamplePage =
     path.startsWith(`/zh/examples`) || path.startsWith(`/en/examples`);
-  const isDocs = path.startsWith(`/zh/docs`) || path.startsWith(`/en/docs`);
+  const isDocsPage = path.startsWith(`/zh/docs`) || path.startsWith(`/en/docs`);
+  const is404Page = (location as any).key === 'initial';
 
   return (
     <RCFooter
@@ -150,7 +151,7 @@ const Footer: React.FC<FooterProps> = ({
       theme={theme}
       columns={columns || [...defaultColumns, more]}
       className={classnames(styles.footer, {
-        [styles.asideMenu]: isGallery || isDocs,
+        [styles.withMenu]: !is404Page && (isExamplePage || isDocsPage),
       })}
       bottom={
         bottom || (

--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -99,6 +99,7 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
       versions,
     },
   } = site;
+
   let resources = {};
   try {
     resources = JSON.parse(locales.internal.content);
@@ -202,11 +203,14 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
         {...logoProps}
       />
       <main className={styles.main}>{children}</main>
-      <Footer
-        githubUrl={githubUrl}
-        rootDomain="https://antv.vision"
-        footerProps={footerProps}
-      />
+      {children && (children.type as any).noFooter ? null : (
+        <Footer
+          githubUrl={githubUrl}
+          rootDomain="https://antv.vision"
+          footerProps={footerProps}
+          location={location}
+        />
+      )}
     </>
   );
 };

--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -203,14 +203,12 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
         {...logoProps}
       />
       <main className={styles.main}>{children}</main>
-      {children && (children.type as any).noFooter ? null : (
-        <Footer
-          githubUrl={githubUrl}
-          rootDomain="https://antv.vision"
-          footerProps={footerProps}
-          location={location}
-        />
-      )}
+      <Footer
+        githubUrl={githubUrl}
+        rootDomain="https://antv.vision"
+        footerProps={footerProps}
+        location={location}
+      />
     </>
   );
 };

--- a/@antv/gatsby-theme-antv/site/pages/404.tsx
+++ b/@antv/gatsby-theme-antv/site/pages/404.tsx
@@ -23,4 +23,7 @@ const NotFoundPage = () => (
   </>
 );
 
+// 标记 404 页面不显示 footer
+NotFoundPage.noFooter = true;
+
 export default NotFoundPage;

--- a/@antv/gatsby-theme-antv/site/pages/404.tsx
+++ b/@antv/gatsby-theme-antv/site/pages/404.tsx
@@ -23,7 +23,4 @@ const NotFoundPage = () => (
   </>
 );
 
-// 标记 404 页面不显示 footer
-NotFoundPage.noFooter = true;
-
 export default NotFoundPage;

--- a/@antv/gatsby-theme-antv/site/templates/document.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/document.tsx
@@ -46,6 +46,11 @@ const getDocument = (docs: any[], slug = '', level: number) => {
   return docs.find((doc) => doc.slug === slug);
 };
 
+// https://github.com/antvis/gatsby-theme-antv/issues/114
+const parseTableOfContents = (tableOfContents: string) => {
+  return tableOfContents.replace(/\/#/g, '#');
+};
+
 interface MenuData {
   type: 'SubMenu' | 'Item';
   title: string;
@@ -274,7 +279,7 @@ export default function Template({
               className={styles.toc}
               /* eslint-disable-next-line react/no-danger */
               dangerouslySetInnerHTML={{
-                __html: tableOfContents,
+                __html: parseTableOfContents(tableOfContents),
               }}
             />
           </Affix>

--- a/@antv/gatsby-theme-antv/site/templates/document.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/document.tsx
@@ -223,7 +223,11 @@ export default function Template({
   const isWide = useMedia('(min-width: 767.99px)', true);
   const [drawOpen, setDrawOpen] = useState(false);
   const menuSider = (
-    <Affix offsetTop={8} className={styles.affix}>
+    <Affix
+      offsetTop={0}
+      className={styles.affix}
+      style={{ height: isWide ? '100vh' : 'inherit' }}
+    >
       {isWide ? (
         <AntLayout.Sider width="auto" theme="light" className={styles.sider}>
           {menu}

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -247,7 +247,11 @@ export default function Template({
   const isWide = useMedia('(min-width: 767.99px)', true);
   const [drawOpen, setDrawOpen] = useState(false);
   const menuSider = (
-    <Affix offsetTop={8} className={styles.affix}>
+    <Affix
+      offsetTop={0}
+      className={styles.affix}
+      style={{ height: isWide ? '100vh' : 'inherit' }}
+    >
       {isWide ? (
         <AntLayout.Sider width="auto" theme="light" className={styles.sider}>
           {menu}

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -1,5 +1,8 @@
 @import '~antd/es/style/themes/default.less';
 
+// 参考 yuque 右侧 tabOfContent 宽度
+@toc-width: 204px;
+
 .markdown {
   font-size: 14px;
   line-height: 2;
@@ -155,7 +158,7 @@
 }
 
 .main {
-  width: calc(100% - 160px);
+  width: calc(100% - @toc-width);
   padding-left: 48px;
   padding-right: 24px;
   overflow: hidden;
@@ -188,11 +191,12 @@
   }
 }
 
+// reference yuque UI
 .toc {
-  width: 160px;
+  width: @toc-width;
   border-left: 2px solid #eee;
   float: right;
-  font-size: 13px;
+  font-size: 12px;
   background: #fff;
   max-height: calc(100vh - 8px);
   overflow: auto;
@@ -201,6 +205,11 @@
     list-style: none !important;
     padding: 0 !important;
     margin-left: 1em !important;
+
+    // 超出部分省略号显示
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 
     a {
       color: @text-color;
@@ -211,11 +220,21 @@
 .sider {
   width: 280px !important;
   height: inherit;
+
+  // menu 滚动
+  :global {
+    .ant-layout-sider-children {
+      overflow-y: scroll;
+      border-right: 1px solid #f0f0f0;
+    }
+
+    .ant-menu-inline {
+      border-right: none;
+    }
+  }
 }
 
 .affix {
-  height: inherit;
-
   & > div {
     height: 100%;
   }

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -224,6 +224,7 @@
   // menu 滚动
   :global {
     .ant-layout-sider-children {
+      overflow-x: hidden;
       overflow-y: auto;
       border-right: 1px solid #f0f0f0;
     }

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -224,7 +224,7 @@
   // menu 滚动
   :global {
     .ant-layout-sider-children {
-      overflow-y: scroll;
+      overflow-y: auto;
       border-right: 1px solid #f0f0f0;
     }
 
@@ -286,7 +286,7 @@
   }
 
   .anchor {
-    width: 160px;
+    width: @toc-width;
     padding-left: 24px;
 
     :global {


### PR DESCRIPTION
* widen tabOfContent from 160px to 204 px referrence to yuque UI;
* tabOfContent ellipsis text;
* make menu can scroll when it over 100vh;
* footer not to be cover;

![2020-09-07 21-56-41 2020-09-07 22_01_05](https://user-images.githubusercontent.com/35586469/92395364-cce07e00-f155-11ea-9fdd-bafb9eafc8a5.gif)

![2020-09-07 21-55-50 2020-09-07 22_03_18](https://user-images.githubusercontent.com/35586469/92395469-f6010e80-f155-11ea-991b-580c5f59ea72.gif)

