### PR TITLE
feat: Read news from My JSON Server

### DIFF
--- a/@antv/gatsby-theme-antv/package.json
+++ b/@antv/gatsby-theme-antv/package.json
@@ -90,6 +90,7 @@
     "monaco-editor": "^0.21.0",
     "monaco-editor-webpack-plugin": "^2.0.0",
     "normalize.css": "^8.0.1",
+    "omit.js": "^2.0.2",
     "parse-github-url": "^1.0.2",
     "prism-themes": "^1.2.0",
     "prismjs": "^1.17.1",

--- a/@antv/gatsby-theme-antv/site/components/APIDoc.tsx
+++ b/@antv/gatsby-theme-antv/site/components/APIDoc.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { Collapse, Skeleton } from 'antd';
 import Mark from 'mark.js';
 import Tabs, { CollapseDataProp } from './Tabs';

--- a/@antv/gatsby-theme-antv/site/components/Banner.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Banner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useStaticQuery, graphql, Link } from 'gatsby';
 import { CaretRightOutlined } from '@ant-design/icons';
 import { Modal } from 'antd';
@@ -65,22 +65,20 @@ const Banner: React.FC<BannerProps> = ({
   const { site } = useStaticQuery(query);
   const { githubUrl } = site.siteMetadata;
 
-  const insNotifications: NotificationProps[] = [
-    {
-      type: t('推荐'),
-      title: t('欢迎进入 2020 可视化智能研发时代'),
-      date: '2020.01.08',
-      link: 'https://www.yuque.com/antv/blog/ygdubv',
-    },
-    {
-      type: t('推荐'),
-      title: t('AntV 11-22 品牌日：知源·致远'),
-      date: '2019.11.22',
-      link: 'https://www.yuque.com/antv/blog/2019-release',
-    },
-  ];
+  const [remoteNews, setRemoteNews] = useState<NotificationProps[]>([]);
 
-  const notificationsNode = (notifications || insNotifications)
+  useEffect(() => {
+    // https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications
+    fetch(
+      `https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications`,
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        setRemoteNews(data);
+      });
+  }, []);
+
+  const notificationsNode = (notifications || remoteNews)
     .slice(0, 2)
     .map((notification, i) => (
       <Notification index={i} key={i} {...notification} />

--- a/@antv/gatsby-theme-antv/site/components/Banner.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Banner.tsx
@@ -51,7 +51,8 @@ const Banner: React.FC<BannerProps> = ({
   onCloseVideo,
   onPlayVideo,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language.includes('zh') ? 'zh' : 'en';
 
   const query = graphql`
     query SiteBannerQuery {
@@ -70,13 +71,13 @@ const Banner: React.FC<BannerProps> = ({
   useEffect(() => {
     // https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications
     fetch(
-      `https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications`,
+      `https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications?lang=${lang}`,
     )
       .then((res) => res.json())
       .then((data) => {
         setRemoteNews(data);
       });
-  }, []);
+  }, [lang]);
 
   const notificationsNode = (notifications || remoteNews)
     .slice(0, 2)

--- a/@antv/gatsby-theme-antv/site/components/Banner.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Banner.tsx
@@ -53,6 +53,7 @@ const Banner: React.FC<BannerProps> = ({
 }) => {
   const { t, i18n } = useTranslation();
   const lang = i18n.language.includes('zh') ? 'zh' : 'en';
+  const notificationsUrl = `https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications?lang=${lang}`;
 
   const query = graphql`
     query SiteBannerQuery {
@@ -69,15 +70,12 @@ const Banner: React.FC<BannerProps> = ({
   const [remoteNews, setRemoteNews] = useState<NotificationProps[]>([]);
 
   useEffect(() => {
-    // https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications
-    fetch(
-      `https://my-json-server.typicode.com/antvis/antvis-sites-data/notifications?lang=${lang}`,
-    )
+    fetch(notificationsUrl)
       .then((res) => res.json())
       .then((data) => {
         setRemoteNews(data);
       });
-  }, [lang]);
+  }, [notificationsUrl]);
 
   const notificationsNode = (notifications || remoteNews)
     .slice(0, 2)

--- a/@antv/gatsby-theme-antv/site/components/CodeLoading.tsx
+++ b/@antv/gatsby-theme-antv/site/components/CodeLoading.tsx
@@ -1,62 +1,50 @@
 import React from 'react';
 
-export default function CodeLoading() {
-  return (
-    <div
-      style={{
-        position: 'relative',
-        height: '100%',
-      }}
-    >
-      <div className="code-loading">
-        <div>
-          <div className="loader">
-            <svg viewBox="0 0 80 80">
-              <defs>
-                <linearGradient
-                  id="gradient"
-                  x1=".004%"
-                  x2="100.131%"
-                  y1="49.993%"
-                  y2="49.993%"
-                >
-                  <stop offset="0%" stopColor="#6500FF" />
-                  <stop offset="16%" stopColor="#6A09FF" />
-                  <stop offset="43%" stopColor="#7623FF" />
-                  <stop offset="77%" stopColor="#8A4CFF" />
-                  <stop offset="99%" stopColor="#996BFF" />
-                </linearGradient>
-              </defs>
-              <circle
-                id="test"
-                cx="40"
-                cy="40"
-                r="32"
-                stroke="url(#gradient)"
-              />
-            </svg>
-          </div>
-          <div className="loader triangle">
-            <svg viewBox="0 0 86 80">
-              <polygon points="43 8 79 72 7 72" stroke="url(#gradient)" />
-            </svg>
-          </div>
-          <div className="loader">
-            <svg viewBox="0 0 80 80">
-              <rect
-                x="8"
-                y="8"
-                width="64"
-                height="64"
-                stroke="url(#gradient)"
-              />
-            </svg>
-          </div>
-          <div className="loading-text">
-            <p>Loading...</p>
-          </div>
+const CodeLoading: React.FC = () => (
+  <div
+    style={{
+      position: 'relative',
+      height: '100%',
+    }}
+  >
+    <div className="code-loading">
+      <div>
+        <div className="loader">
+          <svg viewBox="0 0 80 80">
+            <defs>
+              <linearGradient
+                id="gradient"
+                x1=".004%"
+                x2="100.131%"
+                y1="49.993%"
+                y2="49.993%"
+              >
+                <stop offset="0%" stopColor="#6500FF" />
+                <stop offset="16%" stopColor="#6A09FF" />
+                <stop offset="43%" stopColor="#7623FF" />
+                <stop offset="77%" stopColor="#8A4CFF" />
+                <stop offset="99%" stopColor="#996BFF" />
+              </linearGradient>
+            </defs>
+            <circle id="test" cx="40" cy="40" r="32" stroke="url(#gradient)" />
+          </svg>
+        </div>
+        <div className="loader triangle">
+          <svg viewBox="0 0 86 80">
+            <polygon points="43 8 79 72 7 72" stroke="url(#gradient)" />
+          </svg>
+        </div>
+        <div className="loader">
+          <svg viewBox="0 0 80 80">
+            <rect x="8" y="8" width="64" height="64" stroke="url(#gradient)" />
+          </svg>
+        </div>
+        <div className="loading-text">
+          <p>Loading...</p>
         </div>
       </div>
     </div>
-  );
-}
+  </div>
+);
+
+export default CodeLoading;

--- a/@antv/gatsby-theme-antv/site/components/Footer.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Footer.tsx
@@ -29,7 +29,6 @@ const Footer: React.FC<FooterProps> = ({
   language,
   rootDomain = '',
   location,
-  githubUrl,
   ...resetProps
 }) => {
   const { t, i18n } = useTranslation();
@@ -144,6 +143,8 @@ const Footer: React.FC<FooterProps> = ({
     path.startsWith(`/zh/examples`) || path.startsWith(`/en/examples`);
   const isDocsPage = path.startsWith(`/zh/docs`) || path.startsWith(`/en/docs`);
   const is404Page = (location as any).key === 'initial';
+
+  delete resetProps.githubUrl;
 
   return (
     <RCFooter

--- a/@antv/gatsby-theme-antv/site/components/Footer.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Footer.tsx
@@ -8,6 +8,7 @@ import {
   ZhihuOutlined,
 } from '@ant-design/icons';
 import classnames from 'classnames';
+import omit from 'omit.js';
 import { getProducts } from './getProducts';
 import { useChinaMirrorHost } from '../hooks';
 import styles from './Footer.module.less';
@@ -29,7 +30,7 @@ const Footer: React.FC<FooterProps> = ({
   language,
   rootDomain = '',
   location,
-  ...resetProps
+  ...restProps
 }) => {
   const { t, i18n } = useTranslation();
   const lang = language || i18n.language;
@@ -144,8 +145,6 @@ const Footer: React.FC<FooterProps> = ({
   const isDocsPage = path.startsWith(`/zh/docs`) || path.startsWith(`/en/docs`);
   const is404Page = (location as any).key === 'initial';
 
-  delete resetProps.githubUrl;
-
   return (
     <RCFooter
       maxColumnsPerRow={4}
@@ -195,7 +194,7 @@ const Footer: React.FC<FooterProps> = ({
           </div>
         )
       }
-      {...resetProps}
+      {...omit(restProps, ['githubUrl'])}
     />
   );
 };

--- a/@antv/gatsby-theme-antv/site/components/Footer.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Footer.tsx
@@ -29,6 +29,7 @@ const Footer: React.FC<FooterProps> = ({
   language,
   rootDomain = '',
   location,
+  githubUrl,
   ...resetProps
 }) => {
   const { t, i18n } = useTranslation();


### PR DESCRIPTION
AntV 系列官网首页有一个推广链接列表，目前依赖各站点手动维护，需要重新部署才能生效，批量修改的效率很低。

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/507615/97867308-92a3ef00-1d48-11eb-992b-caa745ed7f4f.png">

现在通过 https://my-json-server.typicode.com/ 服务建了一个免费简单的 Headless CMS，数据放在单独的仓库 https://github.com/antvis/antvis-sites-data ，后续需要修改直接在线修改 [db.json](https://github.com/antvis/antvis-sites-data/edit/main/db.json) 即可，提交即生效。

AntV 系列站点若未定义 Banner 的 notifications，会默认取这里的数据，否则走自定义的数据。这样统一修改 AntV 所有站点的通知内容会很方便。

可用数据接口请查看：https://my-json-server.typicode.com/antvis/antvis-sites-data

- [ ] AntV 系列官网升级到最新版本的主题。
- [ ] 若无必要，去掉各个官网内自己加的 notifications，统一读公用的版本。

---

antd 也有类似的需求：https://github.com/ant-design/ant-design/issues/27389