### PR TITLE
gallery 页面图片和文字居中对齐，清一色居左对齐看起来好累

### DIFF
--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -379,6 +379,7 @@
 
       h4 {
         margin: 16px 0 0;
+        text-align: center;
         color: #101424;
         font-size: 16px;
         line-height: 22px;


### PR DESCRIPTION
对于这种文字比较短的是硬伤，视觉不平衡
![image](https://user-images.githubusercontent.com/6045824/100582152-c4967a00-3323-11eb-94b7-3ef19bb43b98.png)

改一下看起来舒服
![image](https://user-images.githubusercontent.com/6045824/100582192-d4ae5980-3323-11eb-8530-1de65eeffe35.png)

再看看 G6 的

![image](https://user-images.githubusercontent.com/6045824/100582031-8ac57380-3323-11eb-9163-9bbdc4a41200.png)

修改后

![image](https://user-images.githubusercontent.com/6045824/100582063-a03a9d80-3323-11eb-9ba5-eef5cf3107ff.png)
