### PR TITLE
fix: Add English comment to auto-comment of insertCss

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/MdPlayground.tsx
+++ b/@antv/gatsby-theme-antv/site/components/MdPlayground.tsx
@@ -68,6 +68,9 @@ const PlayGround: React.FC<PlayGroundProps> = ({
       `// 我们用 insert-css 演示引入自定义样式
 // 推荐将样式添加到自己的样式文件中
 // 若拷贝官方代码，别忘了 npm install insert-css
+// We use 'insert-css' to insert custom styles
+// It is recommended to add the style to your own style sheet files
+// If you want to copy the code directly, please remember to install the npm package 'insert-css'
 insertCss(`,
     );
   };

--- a/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
@@ -120,6 +120,9 @@ const PlayGround: React.FC<PlayGroundProps> = ({
       `// 我们用 insert-css 演示引入自定义样式
 // 推荐将样式添加到自己的样式文件中
 // 若拷贝官方代码，别忘了 npm install insert-css
+// We use 'insert-css' to insert custom styles
+// It is recommended to add the style to your own style sheet files
+// If you want to copy the code directly, please remember to install the npm package 'insert-css'
 insertCss(`,
     );
   };


### PR DESCRIPTION
insertCss 自动添加的注释需要一个英文翻译。因为咱是个国际化的项目呗。demo代码里面也不支持i18n切换，注释要么英文要么中英双语吧。