### PR TITLE
fix: side menu broder style

### DIFF
--- a/@antv/gatsby-theme-antv/site/layouts/layout.module.less
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.module.less
@@ -12,33 +12,4 @@
 
 .main {
   min-height: 66vh;
-
-  // &:empty {
-  //   height: 100vh;
-  //   display: flex;
-  //   align-items: center;
-  //   justify-content: center;
-
-  //   &:after {
-  //     content: ' ';
-  //     display: block;
-  //     width: 64px;
-  //     height: 64px;
-  //     margin: 8px;
-  //     border-radius: 50%;
-  //     border: 2px solid #873bf4;
-  //     border-color: #873bf4 transparent #873bf4 transparent;
-  //     animation: lds-dual-ring 1.2s linear infinite;
-  //   }
-  // }
 }
-
-// @keyframes lds-dual-ring {
-//   0% {
-//     transform: rotate(0deg);
-//   }
-
-//   100% {
-//     transform: rotate(360deg);
-//   }
-// }

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -261,17 +261,12 @@
 
   // menu 滚动
   :global {
-    .ant-layout-sider-children:hover {
-      overflow-y: auto;
-    }
-
     .ant-layout-sider-children {
       overflow: hidden;
-      border-right: 1px solid #f0f0f0;
-    }
 
-    .ant-menu-inline {
-      border-right: none;
+      &:hover {
+        overflow-y: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
| before ❌ | after ✔️ |
| --- | --- |
| <img width="497" alt="图片" src="https://user-images.githubusercontent.com/507615/105950972-4dbef880-60aa-11eb-87c8-430ef4539089.png"> | <img width="498" alt="图片" src="https://user-images.githubusercontent.com/507615/105951174-98d90b80-60aa-11eb-894e-1667dc16b769.png"> |

这段代码在 https://github.com/antvis/gatsby-theme-antv/commit/058cd75524b43bf081ed1f1016c91bdf28cf308f#diff-c7e14ccebbf9f624feeb0d3e4dd7601c4e768879c2e60a5f0c8f9fb45374eb94R223 里加的。




