### PR TITLE
fix: 修复 md playground 设置宽度不生效 & 版本锁定解决playground无法运作

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/APIDoc.tsx
+++ b/@antv/gatsby-theme-antv/site/components/APIDoc.tsx
@@ -4,7 +4,6 @@ import Icon from '@ant-design/icons';
 import Mark from 'mark.js';
 import { useTranslation } from 'react-i18next';
 import Tabs, { CollapseDataProp } from './Tabs';
-import CollapseIcon from './CollapseIcon';
 import EmptySvg from '../images/empty.svg';
 
 import styles from './APIDoc.module.less';

--- a/@antv/gatsby-theme-antv/site/components/MdPlayground.tsx
+++ b/@antv/gatsby-theme-antv/site/components/MdPlayground.tsx
@@ -67,7 +67,11 @@ const PlayGround: React.FC<PlayGroundProps> = ({
   );
 
   const { extraLib = '' } = site.siteMetadata.playground;
-  const splitPaneSize = get(site.siteMetadata, ['splitPaneMainSize'], '62%');
+  const splitPaneSize = get(
+    site.siteMetadata,
+    ['mdPlayground', 'splitPaneMainSize'],
+    '62%',
+  );
   const { t, i18n } = useTranslation();
   const playgroundNode = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<Error | null>();

--- a/example/api-extractor.json
+++ b/example/api-extractor.json
@@ -11,5 +11,17 @@
   },
   "tsdocMetadata": {
     "enabled": false
+  },
+  "messages": {
+    "extractorMessageReporting": {
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-param-tag-missing-hyphen": {
+        "logLevel": "none"
+      }
+    }
   }
 }

--- a/example/docs/api/g2plot/scatter.en.md
+++ b/example/docs/api/g2plot/scatter.en.md
@@ -1,0 +1,10 @@
+---
+title: Scatter
+order: 1
+---
+
+### 图表容器
+
+`markdown:docs/common/chart-options.en.md`
+
+<playground path='basic/demo/ts-demo.ts' rid='rect'></playground>

--- a/example/docs/api/g2plot/scatter.zh.md
+++ b/example/docs/api/g2plot/scatter.zh.md
@@ -1,0 +1,10 @@
+---
+title: 散点图
+order: 1
+---
+
+### 图表容器
+
+`markdown:docs/common/chart-options.zh.md`
+
+<playground path='basic/demo/ts-demo.ts' rid='rect'></playground>

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -69,16 +69,16 @@ module.exports = {
       {
         slug: 'api/antv',
         title: {
-          zh: '测试 g2',
-          en: 'test g2',
+          zh: '测试 G2',
+          en: 'test G2',
         },
         order: 0,
       },
       {
         slug: 'api/g2plot',
         title: {
-          zh: 'g2plot',
-          en: 'g2plot',
+          zh: 'G2Plot',
+          en: 'G2Plot',
         },
         order: 1,
       },
@@ -120,6 +120,10 @@ module.exports = {
     </script>
   </body>
 </html>`,
+    },
+    mdPlayground: {
+      // markdown 文档中的 playground 若干设置
+      splitPaneMainSize: '50%',
     },
     redirects: [],
   },

--- a/package.json
+++ b/package.json
@@ -44,5 +44,10 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "resolutions": {
+    "monaco-editor": "0.21.3",
+    "@babel/plugin-transform-spread": "7.12.1",
+    "@babel/standalone": "7.12.6"
   }
 }


### PR DESCRIPTION
之前加的配置，可以设置宽度 50%，如下（不生效）

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/15646325/112998787-f409a600-91a0-11eb-8ef8-841a20522310.png)|![image](https://user-images.githubusercontent.com/15646325/112998679-da685e80-91a0-11eb-9f1d-13a5fad975f8.png)|
