### PR TITLE
feat: header 增加下拉菜单，可以存放一些生态的外链

### DIFF
--- a/@antv/gatsby-theme-antv/gatsby-node.js
+++ b/@antv/gatsby-theme-antv/gatsby-node.js
@@ -463,6 +463,11 @@ exports.sourceNodes = ({ actions }) => {
       en: String
     }
 
+    type SiteSiteMetadataEcosystemName {
+      zh: String
+      en: String
+    }
+
     type SiteSiteMetadataDocs {
       slug: String!
       title: SiteSiteMetadataTitle!
@@ -488,7 +493,7 @@ exports.sourceNodes = ({ actions }) => {
     }
 
     type Ecosystems {
-      name: String!
+      name: SiteSiteMetadataEcosystemName!
       url: String!
     }
 

--- a/@antv/gatsby-theme-antv/gatsby-node.js
+++ b/@antv/gatsby-theme-antv/gatsby-node.js
@@ -487,6 +487,11 @@ exports.sourceNodes = ({ actions }) => {
       to: String
     }
 
+    type Ecosystems {
+      name: String!
+      url: String!
+    }
+
     type SiteSiteMetadata {
       title: String!
       description: String!
@@ -511,6 +516,7 @@ exports.sourceNodes = ({ actions }) => {
       playground: PlayGround
       docsearchOptions: DocsearchOptions
       versions: Json
+      ecosystems: [Ecosystems]
     }
 
     type Site implements Node {

--- a/@antv/gatsby-theme-antv/site/components/Header.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Header.tsx
@@ -9,9 +9,11 @@ import {
   GithubOutlined,
   MenuOutlined,
   CaretDownFilled,
+  DownOutlined,
 } from '@ant-design/icons';
 import { Popover, Button, Menu, Select, Dropdown, message, Modal } from 'antd';
 import GitUrlParse from 'git-url-parse';
+import map from 'lodash/map';
 import Search, { SearchProps } from './Search';
 import Products from './Products';
 import NavMenuItems, { Nav } from './NavMenuItems';
@@ -70,6 +72,8 @@ interface HeaderProps {
   docsearchOptions?: SearchProps['docsearchOptions'];
   /** 展示版本切换 */
   versions?: { [key: string]: string };
+  /** 展示周边生态 */
+  ecosystems?: Array<{ name: string; url: string }>;
 }
 
 export const redirectToChinaMirror = (githubUrl: string): void => {
@@ -124,6 +128,7 @@ const Header: React.FC<HeaderProps> = ({
   rootDomain = '',
   docsearchOptions,
   versions,
+  ecosystems,
 }) => {
   const { t, i18n } = useTranslation();
   const isAntVHome = isAntVSite && isHomePage; // 是否为AntV官网首页
@@ -243,6 +248,28 @@ const Header: React.FC<HeaderProps> = ({
       })}
     >
       {navs && navs.length ? <NavMenuItems navs={navs} path={path} /> : null}
+      {ecosystems && ecosystems.length ? (
+        <li>
+          <Dropdown
+            overlay={
+              <Menu>
+                {map(ecosystems, ({ url, name: ecosystemName }) => (
+                  <Menu.Item key={ecosystemName}>
+                    <a target="_blank" href={url}>
+                      {ecosystemName} <ExternalLinkIcon />
+                    </a>
+                  </Menu.Item>
+                ))}
+              </Menu>
+            }
+          >
+            <span>
+              {t('周边生态')}
+              <DownOutlined style={{ marginLeft: '6px' }} />
+            </span>
+          </Dropdown>
+        </li>
+      ) : null}
       {showChinaMirror && isWide ? (
         <Popover
           title={null}
@@ -398,6 +425,7 @@ const Header: React.FC<HeaderProps> = ({
           </Select>
         </li>
       ) : null}
+
       {showLanguageSwitcher && (
         <li>
           <Dropdown
@@ -453,7 +481,7 @@ const Header: React.FC<HeaderProps> = ({
             >
               <TranslationIcon className={styles.translation} />
             </a>
-          </Dropdown>
+          </Dropdown>{' '}
         </li>
       )}
       {showGithubCorner && (

--- a/@antv/gatsby-theme-antv/site/components/Header.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Header.tsx
@@ -73,7 +73,10 @@ interface HeaderProps {
   /** 展示版本切换 */
   versions?: { [key: string]: string };
   /** 展示周边生态 */
-  ecosystems?: Array<{ name: string; url: string }>;
+  ecosystems?: Array<{
+    name: Record<string /** zh, en */, string>;
+    url: string;
+  }>;
 }
 
 export const redirectToChinaMirror = (githubUrl: string): void => {
@@ -254,9 +257,9 @@ const Header: React.FC<HeaderProps> = ({
             overlay={
               <Menu>
                 {map(ecosystems, ({ url, name: ecosystemName }) => (
-                  <Menu.Item key={ecosystemName}>
+                  <Menu.Item key={ecosystemName?.[lang]}>
                     <a target="_blank" rel="noreferrer" href={url}>
-                      {ecosystemName} <ExternalLinkIcon />
+                      {ecosystemName?.[lang]} <ExternalLinkIcon />
                     </a>
                   </Menu.Item>
                 ))}
@@ -481,7 +484,7 @@ const Header: React.FC<HeaderProps> = ({
             >
               <TranslationIcon className={styles.translation} />
             </a>
-          </Dropdown>{' '}
+          </Dropdown>
         </li>
       )}
       {showGithubCorner && (

--- a/@antv/gatsby-theme-antv/site/components/Header.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Header.tsx
@@ -255,7 +255,7 @@ const Header: React.FC<HeaderProps> = ({
               <Menu>
                 {map(ecosystems, ({ url, name: ecosystemName }) => (
                   <Menu.Item key={ecosystemName}>
-                    <a target="_blank" href={url}>
+                    <a target="_blank" rel="noreferrer" href={url}>
                       {ecosystemName} <ExternalLinkIcon />
                     </a>
                   </Menu.Item>

--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -75,7 +75,10 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
           }
           versions
           ecosystems {
-            name
+            name {
+              zh
+              en
+            }
             url
           }
         }

--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -74,6 +74,10 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
             indexName
           }
           versions
+          ecosystems {
+            name
+            url
+          }
         }
       }
       locales {
@@ -100,6 +104,7 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
       redirects = [],
       docsearchOptions,
       versions,
+      ecosystems,
     },
   } = site;
 
@@ -204,6 +209,7 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
         showLanguageSwitcher={parseNulltoUndefined(showLanguageSwitcher)}
         docsearchOptions={docsearchOptions}
         versions={versions}
+        ecosystems={ecosystems}
         {...logoProps}
       />
       <main className={styles.main}>{children}</main>

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -100,11 +100,17 @@ module.exports = {
     },
     ecosystems: [
       {
-        name: 'Antd Charts',
+        name: {
+          zh: '蚂蚁设计',
+          en: 'Ant Design',
+        },
         url: 'https://2x.ant.design',
       },
       {
-        name: 'ChartCube',
+        name: {
+          zh: '图表加工厂',
+          en: 'ChartCube',
+        },
         url: 'https://chartcube.alipay.com/',
       },
     ],

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -98,6 +98,16 @@ module.exports = {
       '2.x': 'https://2x.ant.design',
       '1.x': 'https://1x.ant.design',
     },
+    ecosystems: [
+      {
+        name: 'Antd Charts',
+        url: 'https://2x.ant.design',
+      },
+      {
+        name: 'ChartCube',
+        url: 'https://chartcube.alipay.com/',
+      },
+    ],
     playground: {
       container: '<div id="container" class="ok" />',
       playgroundDidMount: 'console.log("playgroundDidMount");',


### PR DESCRIPTION
背景：头部平铺菜单项太多，需要收拢（暂时收口到【周边生态】里边）

| 配置方式 | 效果 |
| --- | --- |
|![image](https://user-images.githubusercontent.com/15646325/113805414-126c3480-9793-11eb-888c-c338a8b95b29.png)| ![image](https://user-images.githubusercontent.com/15646325/113805389-07b19f80-9793-11eb-867c-4f9f976498c7.png)|