### PR TITLE
fix(announcement): 公告判空不展示

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/TopBanner.tsx
+++ b/@antv/gatsby-theme-antv/site/components/TopBanner.tsx
@@ -20,18 +20,16 @@ const TopBanner: React.FC<Props> = ({ announcement }) => {
     return announcement ? announcement.en : '';
   }, [announcement]);
 
-  return (
+  const content = get(announcement, i18n.language);
+
+  return content ? (
     <Announcement
-      message={
-        <span className={styles.topBannerAnnouncements}>
-          {get(announcement, i18n.language)}
-        </span>
-      }
+      message={<span className={styles.topBannerAnnouncements}>{content}</span>}
       bannerId={bannerId}
       localStorageId={BANNER_LOCALSTORAGE_KEY}
       style={{ borderRadius: 0, borderWidth: '1px 0' }}
     />
-  );
+  ) : null;
 };
 
 export default TopBanner;

--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -193,6 +193,10 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
       }
     : {};
 
+  const isExamplePage =
+    location.pathname.includes('/examples/') &&
+    !location.pathname.endsWith('/gallery');
+
   return (
     <>
       {rediectUrl && (
@@ -225,13 +229,12 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
         ecosystems={ecosystems}
         {...logoProps}
       />
-      {/* 首页不展示 头部 banner */}
-      {!isHomePage && <TopBanner announcement={announcement} />}
+      {/* 首页和 example 演示页 不展示 头部 banner */}
+      {!isHomePage && !isExamplePage && (
+        <TopBanner announcement={announcement} />
+      )}
       <main className={styles.main}>{children}</main>
-      {!(
-        location.pathname.includes('/examples/') &&
-        !location.pathname.endsWith('/gallery')
-      ) && (
+      {!isExamplePage && (
         <Footer
           githubUrl={githubUrl}
           rootDomain="https://antv.vision"

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -364,23 +364,25 @@ export default function Template({
           }}
         />
         {/* 是否展示上新公告  */}
-        <Announcement
-          message={
-            <div>
-              {t('上新啦，点击直达：')}
-              {demosOnTheNew.map((demo, idx) => (
-                <span key={demo.title}>
-                  {idx !== 0 && '，'}
-                  <a href={`#category-${demo.category.replace(/\s/g, '')}`}>
-                    {demo.title}
-                  </a>
-                </span>
-              ))}
-            </div>
-          }
-          localStorageId={BANNER_LOCALSTORAGE_KEY}
-          bannerId={bannerId}
-        />
+        {demosOnTheNew.length && (
+          <Announcement
+            message={
+              <div>
+                {t('上新啦，点击直达：')}
+                {demosOnTheNew.map((demo, idx) => (
+                  <span key={demo.title}>
+                    {idx !== 0 && '，'}
+                    <a href={`#category-${demo.category.replace(/\s/g, '')}`}>
+                      {demo.title}
+                    </a>
+                  </span>
+                ))}
+              </div>
+            }
+            localStorageId={BANNER_LOCALSTORAGE_KEY}
+            bannerId={bannerId}
+          />
+        )}
         {Categories.map((category: string, i) => (
           <div key={i}>
             {category !== 'OTHER' && (

--- a/example/examples/radar/basic/demo/meta.json
+++ b/example/examples/radar/basic/demo/meta.json
@@ -28,7 +28,8 @@
         "zh": "雷达图-tooltip 添加辅助线",
         "en": "Rardar chart with tooltip crosshairs"
       },
-      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*r46-T43zmzwAAAAAAAAAAAAAARQnAQ"
+      "screenshot": "https://gw.alipayobjects.com/mdn/rms_d314dd/afts/img/A*r46-T43zmzwAAAAAAAAAAAAAARQnAQ",
+      "new": true
     }
   ]
 }


### PR DESCRIPTION
- [x] fix: 没有公告内容和新 demo 的时候不展示
- [x] feat: 优化顶部公告展示逻辑，example 演示页不展示头部公告
- [x] 同一系列图表上新之后，公告处展示过多 -> 优化为：只展示图表系列的分类名称
        - [x] 优化图表上新公告展示逻辑：大于4个新增 demo 或全部新增，则直接使用 category 作为代替

| Before | After |
| --- | --- |
|![image](https://user-images.githubusercontent.com/15646325/119375503-74560e80-bced-11eb-8885-0e7495117309.png), ![image](https://user-images.githubusercontent.com/15646325/119375529-7cae4980-bced-11eb-8de4-9d723c90d5a8.png)| ![image](https://user-images.githubusercontent.com/15646325/119377027-378b1700-bcef-11eb-9ee9-a70b4fb49300.png), ![image](https://user-images.githubusercontent.com/15646325/119377060-41147f00-bcef-11eb-99a1-4b08fdc229ba.png) |

