### PR TITLE
fix:  去除page中传递的posts 修改跨二级菜单的跳转方法

### DIFF
--- a/@antv/gatsby-theme-antv/gatsby-node.js
+++ b/@antv/gatsby-theme-antv/gatsby-node.js
@@ -307,34 +307,27 @@ exports.createPages = async ({ actions, graphql, reporter, store }) => {
         )
         .sort((a, b) => a.order - b.order);
 
-      const newPosts = posts
-        .filter(item => item.node.html)
-        .reduce((designPost, item) => {
-          if (/^\/(en|zh)\/examples\/.*?(?=design)/.test(item.node.fields.slug)) {
-            designPost.designs[item.node.fields.slug.replace('/design', '').replace('/examples', '')] = item.node.html;
-          } else if (/^\/(en|zh)\/examples\/.*?(?=API)/.test(item.node.fields.slug)) {
-            designPost.APIs[item.node.fields.slug.replace('/API', '').replace('/examples', '')] = item.node.html;
-          } else if (/^\/(en|zh)\/examples\/(?!.*(API|design))/.test(item.node.fields.slug)) {
-            designPost.descriptions[item.node.fields.slug.replace('/examples', '')] = item.node.html;
-          }
-          return designPost;
-        }, {
-          designs: {},
-          APIs: {},
-          descriptions: {},
-        });
+      const design = posts.find((post) => {
+        const { slug: postSlug } = post.node.fields;
+        return postSlug === `${exampleRootSlug}/design`;
+      });
+      const API = posts.find((post) => {
+        const { slug: postSlug } = post.node.fields;
+        return postSlug === `${exampleRootSlug}/API`;
+      });
 
-      context.exampleSections = {
-        examples,
-        ...newPosts
-      };
       const descriptionPosts = posts.find((post) => {
         const { slug: postSlug } = post.node.fields;
         return postSlug === exampleRootSlug;
       });
-      if (descriptionPosts) {
-        context.description = descriptionPosts.node.html;
-      }
+
+      context.exampleSections = {
+        examples,
+        API,
+        design,
+        description: descriptionPosts && descriptionPosts.node.html,
+      };
+
     } else if (isDocsPage) {
       // 将 examples 传递给 document template
       context.examples = allExamples;

--- a/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
@@ -36,7 +36,6 @@ const { Content, Sider } = Layout;
 interface PlayGroundProps {
   exampleSections: any;
   location: Location;
-  description: string;
   markdownRemark: any;
   categories: string[];
   allDemos: any;
@@ -99,6 +98,9 @@ const PlayGround: React.FC<PlayGroundProps> = ({
   treeData,
   examples,
 }) => {
+
+  const { API, design, description } = exampleSections;
+
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -158,10 +160,6 @@ const PlayGround: React.FC<PlayGroundProps> = ({
   const editroRef = useRef<any>(null);
   const isWide = useMedia('(min-width: 767.99px)', true);
 
-  const [description, setDescription] = useState<string>();
-  const [design, setDesign] = useState<NodePost>();
-  const [API, setAPI] = useState<NodePost>();
-
   useEffect(() => {
     if (isBrowser) {
       setPathname(window.location.pathname.replace('/examples', ''));
@@ -170,26 +168,6 @@ const PlayGround: React.FC<PlayGroundProps> = ({
 
   useEffect(() => {
     if (!pathname) return;
-    // 获取最新的 description 示例 设计指引 1
-    const desc = exampleSections.descriptions[pathname];
-    setDescription(desc);
-
-    // 获取最新的 design 示例 设计指引 2
-    const newDesign = {
-      node: {
-        html: exampleSections.designs[`${pathname}`],
-      },
-    };
-    setDesign(newDesign);
-
-    // 获取最新的 API 文档
-    const newAPI = {
-      node: {
-        html: exampleSections.APIs[`${pathname}`],
-      },
-    };
-    setAPI(newAPI);
-
     updateDocsEmpty(!design?.node?.html && !description && !API?.node?.html);
   }, [pathname]);
 

--- a/@antv/gatsby-theme-antv/site/components/PlayGrounds.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGrounds.tsx
@@ -209,8 +209,12 @@ const PlayGrounds: React.FC<PlayGroundsProps> = ({
             cursor: 'pointer',
           }}
           onClick={() => {
-            window.history.pushState({}, '', `${item.value}`);
-            updateCurrentExample(item as any);
+            if(item.value?.match( window.location.pathname)) {
+              window.history.replaceState({}, '', `${item.value}`);
+              updateCurrentExample(item as any);
+            } else {
+              window.location.href = `${window.location.origin}${item.value}`
+            }
           }}
         >
           <span className={styles.menuTitleContent}>{example(item)}</span>

--- a/@antv/gatsby-theme-antv/site/templates/example.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/example.tsx
@@ -124,7 +124,6 @@ export default function Template({
   pageContext: {
     exampleSections: any;
     allDemos?: any[];
-    description: string;
   };
 }): React.ReactNode {
   const { allMarkdownRemark, site } = data; // data.markdownRemark holds our post data
@@ -175,7 +174,7 @@ export default function Template({
     },
   );
 
-  const { exampleSections = {}, allDemos = [], description = '' } = pageContext;
+  const { exampleSections = {}, allDemos = [] } = pageContext;
 
   const [prev, next] = usePrevAndNext();
 
@@ -411,7 +410,7 @@ export default function Template({
         <div
           /* eslint-disable-next-line react/no-danger */
           dangerouslySetInnerHTML={{
-            __html: description,
+            __html: exampleSections.description,
           }}
         />
         {/* 是否展示上新公告  */}
@@ -512,7 +511,6 @@ export default function Template({
           exampleSections={exampleSections}
           location={location}
           markdownRemark={markdownRemark}
-          description={description}
           treeData={getTreeData()}
         />
       )}


### PR DESCRIPTION
- [x] 当跨二级菜单点击示例时， 进行页面刷新。 在node.js 层删选 API design 等 不用传递过多的posts
![image](https://user-images.githubusercontent.com/65594180/124107998-5fad2900-da98-11eb-9cdf-3f667c1d69c6.png)
