### PR TITLE
fix: 修复抽屉样式

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/APIDoc.module.less
+++ b/@antv/gatsby-theme-antv/site/components/APIDoc.module.less
@@ -49,6 +49,9 @@
           color: #8b99a7;
           position: absolute;
           left: 0px;
+          top: 5.0005px;
+          display: inline-block;
+          padding: 12px 0 0;
         }
       }
 


### PR DESCRIPTION
- [x]  重新加入 竖直居中 的 抽屉 icon  样式 . css 代码从 g2 g2plot 中获取

![image](https://user-images.githubusercontent.com/65594180/126129958-a5b76a61-6c5c-4826-9fc8-2772033ee0fb.png)
![image](https://user-images.githubusercontent.com/65594180/126130486-b5d63eb7-4517-4f57-a1b0-a7b78531e5d7.png)
