### PR TITLE
chore: move `react` and `react-dom` to `peerDependencies`

### DIFF
--- a/@antv/gatsby-theme-antv/package.json
+++ b/@antv/gatsby-theme-antv/package.json
@@ -64,6 +64,10 @@
     "ts-jest": "^26.0.0",
     "typescript": "^4.0.2"
   },
+  "peerDependencies": {
+    "react": "^16.9.0 || ^17.0.0",
+    "react-dom": "^16.9.0 || ^17.0.0"
+  },
   "dependencies": {
     "@ant-design/icons": "^4.1.0",
     "@hot-loader/react-dom": "^16.9.0+4.12.11",
@@ -124,8 +128,6 @@
     "ptz-i18n": "^1.0.0",
     "rc-drawer": "^4.0.0",
     "rc-footer": "^0.6.1",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
     "react-github-btn": "^1.2.0",
     "react-github-button": "^0.1.11",
     "react-helmet": "^6.0.0",


### PR DESCRIPTION
`react` 和 `react-dom` 应该放在 `peerDependencies`, 不然导致一个项目有两个 `react` 版本