### PR TITLE
fix: 修复 arm 芯片下 npm 安装 sharp 报错的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "resolutions": {
     "monaco-editor": "0.21.3",
     "@babel/plugin-transform-spread": "7.12.1",
-    "@babel/standalone": "7.12.6"
+    "@babel/standalone": "7.12.6",
+    "sharp": "^0.29.0"
   }
 }


### PR DESCRIPTION
### 问题描述
在 `M1` 的 `mac` 环境下使用 `yarn install` 会报错，提示  `sharp Prebuilt libvips 8.10.5 binaries are not yet available for darwin-arm64v8`

### 问题追溯

查看 [sharp官网关于M1芯片的说明](https://sharp.pixelplumbing.com/install#apple-m1) 后得知，`0.29.x` 版本才支持 `ARM64`

查看当前sharp版本
```bash
npm list sharp

@antv/gatsby-theme-antv@ /Users/shiyu/DCODE/gatsby-theme-antv
└─┬ @antv/gatsby-theme-antv@1.1.16 -> ./@antv/gatsby-theme-antv
  └─┬ gatsby-plugin-manifest@2.12.1
    └── sharp@0.27.2
```
`gatsby-theme-antv` 依赖 `gatsby-plugin-manifest`的第二个大版本，其中依赖的sharp被锁定在 `0.27.x`

### 解决方案
在 `package.json` 中，利用 `resolutions` 字段，将 `sharp` 版本锁定在 `0.29.x` 以上
