### PR TITLE
fix: page ToC overflowing into footer

### DIFF
--- a/@antv/gatsby-theme-antv/site/templates/document.tsx
+++ b/@antv/gatsby-theme-antv/site/templates/document.tsx
@@ -384,16 +384,26 @@ export default function Template({
       </React.Fragment>
     ));
 
-  const onAnchorLinkChange = debounce((currentActiveLink: string) => {
-    if (currentActiveLink) {
-      const link = document.querySelector(`a[href='${currentActiveLink}']`);
-      if (link) {
-        const anchor = link?.parentNode as Element;
-        anchor.scrollIntoView({
-          block: 'center',
-        });
-      }
-    }
+  const onAnchorLinkChange = debounce((activeLink: string) => {
+    if (!activeLink) return;
+    // We could update URL hash on scroll
+    window.history.replaceState({}, '', activeLink);
+    const anchorElem = document.querySelector(
+      `.${styles.toc} a[href='${activeLink}']`,
+    )?.parentNode as HTMLElement | null;
+    const tocContentElem = document.querySelector<HTMLElement>(
+      `.${styles.apiAnchor}`,
+    );
+    // We can no longer use Element.scrollIntoView
+    // when using a plain `position: sticky` for table of contents
+    // because it will try to scroll the main article as well
+    tocContentElem?.scrollTo({
+      top:
+        Number(anchorElem?.offsetTop) -
+        window.innerHeight / 2 -
+        Number(anchorElem?.clientHeight),
+      behavior: 'smooth',
+    });
   }, 300);
 
   return (
@@ -406,16 +416,15 @@ export default function Template({
       >
         {menuSider}
         <Article className={styles.markdown}>
-          <Affix offsetTop={8}>
-            <div className={styles.toc}>
-              <Anchor
-                className={styles.apiAnchor}
-                onChange={onAnchorLinkChange}
-              >
-                {renderAnchorLinks(anchorLinks)}
-              </Anchor>
-            </div>
-          </Affix>
+          <div className={styles.toc}>
+            <Anchor
+              affix={false}
+              className={styles.apiAnchor}
+              onChange={onAnchorLinkChange}
+            >
+              {renderAnchorLinks(anchorLinks)}
+            </Anchor>
+          </div>
           <div className={styles.main}>
             <h1>
               {frontmatter.title}

--- a/@antv/gatsby-theme-antv/site/templates/markdown.module.less
+++ b/@antv/gatsby-theme-antv/site/templates/markdown.module.less
@@ -242,7 +242,11 @@
   font-size: 12px;
   background: #fff;
   max-height: 100vh;
-  overflow: auto;
+  overflow: scroll;
+
+  position: sticky;
+  top: 0;
+  padding: 8px 0;
 
   ul > li {
     list-style: none !important;


### PR DESCRIPTION
Fixes an issue where the generated table of contents will overlap the footer when the page is scrolled to the bottom, as can be seen in antvis/X6#1940.

This uses a plain `div` with `position: sticky` instead of the `Affix` component.

Before:

https://user-images.githubusercontent.com/93302820/160517847-9a04b501-c867-4f3e-8c89-4550bc49bdaf.mov

After:

https://user-images.githubusercontent.com/93302820/160517860-bcdef26f-f66f-4539-b20a-1abe2caae97b.mov
