### PR TITLE
feat: 新增v3.x版本docsearch适配新申请的子站点

### DIFF
--- a/@antv/gatsby-theme-antv/gatsby-browser.js
+++ b/@antv/gatsby-theme-antv/gatsby-browser.js
@@ -6,6 +6,7 @@
 
 // You can delete this file if you're not using it
 import 'normalize.css/normalize.css';
+import '@docsearch/css';
 import 'prism-themes/themes/prism-base16-ateliersulphurpool.light.css';
 import 'prismjs/plugins/command-line/prism-command-line.css';
 import 'rc-drawer/assets/index.css';

--- a/@antv/gatsby-theme-antv/gatsby-node.js
+++ b/@antv/gatsby-theme-antv/gatsby-node.js
@@ -453,6 +453,8 @@ exports.sourceNodes = ({ actions }) => {
 
   createTypes(`
     type DocsearchOptions {
+      versionV3: Boolean
+      appId: String
       apiKey: String
       indexName: String
     }

--- a/@antv/gatsby-theme-antv/package.json
+++ b/@antv/gatsby-theme-antv/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.1.0",
+    "@docsearch/js": "^3.0.0",
     "@hot-loader/react-dom": "^16.9.0+4.12.11",
     "@loadable/component": "^5.13.2",
     "@microsoft/api-extractor": "^7.9.2",

--- a/@antv/gatsby-theme-antv/site/components/Search.module.less
+++ b/@antv/gatsby-theme-antv/site/components/Search.module.less
@@ -9,7 +9,6 @@
     opacity: 0.75;
     margin-right: 8px;
   }
-
   .input {
     border: none;
     height: 32px;
@@ -20,6 +19,13 @@
 
     &::placeholder {
       color: #a3b1bf;
+    }
+  }
+  :global {
+    .DocSearch-Search-Icon {
+      width: 1em !important;
+      height: 1em !important;
+      color: #a3b1bf !important;
     }
   }
 }

--- a/@antv/gatsby-theme-antv/site/components/Search.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Search.tsx
@@ -60,7 +60,7 @@ const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
   } = docsearchOptions || {};
   const { t, i18n } = useTranslation();
   useEffect(() => {
-    if (typeof window !== 'undefined' && !docsearchOptions?.versionV3) {
+    if (typeof window !== 'undefined' && !versionV3) {
       import('docsearch.js').then(({ default: docsearchV2 }) => {
         initDocSearchV2({
           docsearchV2,

--- a/@antv/gatsby-theme-antv/site/components/Search.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Search.tsx
@@ -52,7 +52,12 @@ function initDocSearchV2({
 }
 
 const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
-  const versionV3 = docsearchOptions?.versionV3;
+  const {
+    apiKey = '194b1be7fb1254c787f4e036912af3eb',
+    indexName = 'antv',
+    versionV3 = false,
+    appId = 'BH4D9OD16A',
+  } = docsearchOptions || {};
   const { t, i18n } = useTranslation();
   useEffect(() => {
     if (typeof window !== 'undefined' && !versionV3) {
@@ -68,11 +73,7 @@ const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
   return (
     <label className={styles.search} htmlFor="search" id="search">
       {versionV3 ? (
-        <DocSearch
-          appId={docsearchOptions?.appId}
-          indexName={docsearchOptions?.indexName}
-          apiKey={docsearchOptions?.apiKey}
-        />
+        <DocSearch appId={appId} indexName={indexName} apiKey={apiKey} />
       ) : (
         <>
           <SearchOutlined className={styles.icon} />

--- a/@antv/gatsby-theme-antv/site/components/Search.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Search.tsx
@@ -1,27 +1,32 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SearchOutlined } from '@ant-design/icons';
+import docsearch from '@docsearch/js';
+
 import styles from './Search.module.less';
 
 export interface SearchProps {
+  // algolia 搜索配置
   docsearchOptions?: {
+    versionV3?: boolean; // 目前有两个版本的 docsearch.js，V2.x 和 V3.x，此开关决定用哪一个版本的搜索框，根据申请到的参数版本决定，二者互不兼容，详情见 https://docsearch.algolia.com/
+    appId?: string; // V3.x 版本 docsearch 需要appId, V2.x 版不需要。
     apiKey: string;
     indexName: string;
   };
 }
 
-function initDocSearch({
-  docsearch,
+function initDocSearchV2({
+  docsearchV2,
   lang,
   docsearchOptions,
 }: {
-  docsearch: any;
+  docsearchV2: any;
   lang: string;
   docsearchOptions: SearchProps['docsearchOptions'];
 }) {
   const { apiKey = '194b1be7fb1254c787f4e036912af3eb', indexName = 'antv' } =
     docsearchOptions || {};
-  docsearch({
+  docsearchV2({
     apiKey,
     indexName,
     inputSelector: `.${styles.input}`,
@@ -49,10 +54,20 @@ function initDocSearch({
 const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
   const { t, i18n } = useTranslation();
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      import('docsearch.js').then(({ default: docsearch }) => {
-        initDocSearch({
-          docsearch,
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (docsearchOptions?.versionV3) {
+      docsearch({
+        container: '#search',
+        apiKey: docsearchOptions?.apiKey,
+        indexName: docsearchOptions?.indexName,
+        appId: docsearchOptions?.appId,
+      });
+    } else {
+      import('docsearch.js').then(({ default: docsearchV2 }) => {
+        initDocSearchV2({
+          docsearchV2,
           lang: i18n.language,
           docsearchOptions,
         });
@@ -60,7 +75,7 @@ const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
     }
   }, []);
   return (
-    <label className={styles.search} htmlFor="search">
+    <label className={styles.search} htmlFor="search" id="search">
       <SearchOutlined className={styles.icon} />
       <input className={styles.input} id="search" placeholder={t('搜索…')} />
     </label>

--- a/@antv/gatsby-theme-antv/site/components/Search.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Search.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SearchOutlined } from '@ant-design/icons';
-import docsearch from '@docsearch/js';
+import { DocSearch } from '@docsearch/react';
 
 import styles from './Search.module.less';
 
@@ -52,19 +52,10 @@ function initDocSearchV2({
 }
 
 const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
+  const versionV3 = docsearchOptions?.versionV3;
   const { t, i18n } = useTranslation();
   useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    if (docsearchOptions?.versionV3) {
-      docsearch({
-        container: '#search',
-        apiKey: docsearchOptions?.apiKey,
-        indexName: docsearchOptions?.indexName,
-        appId: docsearchOptions?.appId,
-      });
-    } else {
+    if (typeof window !== 'undefined' && !versionV3) {
       import('docsearch.js').then(({ default: docsearchV2 }) => {
         initDocSearchV2({
           docsearchV2,
@@ -76,8 +67,22 @@ const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
   }, []);
   return (
     <label className={styles.search} htmlFor="search" id="search">
-      <SearchOutlined className={styles.icon} />
-      <input className={styles.input} id="search" placeholder={t('搜索…')} />
+      {versionV3 ? (
+        <DocSearch
+          appId={docsearchOptions?.appId}
+          indexName={docsearchOptions?.indexName}
+          apiKey={docsearchOptions?.apiKey}
+        />
+      ) : (
+        <>
+          <SearchOutlined className={styles.icon} />
+          <input
+            className={styles.input}
+            id="search"
+            placeholder={t('搜索…')}
+          />
+        </>
+      )}
     </label>
   );
 };

--- a/@antv/gatsby-theme-antv/site/components/Search.tsx
+++ b/@antv/gatsby-theme-antv/site/components/Search.tsx
@@ -53,14 +53,14 @@ function initDocSearchV2({
 
 const Search: React.FC<SearchProps> = ({ docsearchOptions }) => {
   const {
-    apiKey = '194b1be7fb1254c787f4e036912af3eb',
-    indexName = 'antv',
+    apiKey = '',
+    indexName = '',
     versionV3 = false,
-    appId = 'BH4D9OD16A',
+    appId = '',
   } = docsearchOptions || {};
   const { t, i18n } = useTranslation();
   useEffect(() => {
-    if (typeof window !== 'undefined' && !versionV3) {
+    if (typeof window !== 'undefined' && !docsearchOptions?.versionV3) {
       import('docsearch.js').then(({ default: docsearchV2 }) => {
         initDocSearchV2({
           docsearchV2,

--- a/@antv/gatsby-theme-antv/site/layouts/layout.tsx
+++ b/@antv/gatsby-theme-antv/site/layouts/layout.tsx
@@ -75,7 +75,9 @@ const Layout: React.FC<LayoutProps> = ({ children, location, footerProps }) => {
           }
           docsearchOptions {
             apiKey
+            appId
             indexName
+            versionV3
           }
           versions
           ecosystems {

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ module.exports = {
     isAntVSite: false, //是否是AntV官网，header样式footer和图表详情页均为定制
     galleryMenuCloseAll: false, // 是否默认收起 gallery 页面所有 menu
     showSearch: true, // 是否展示搜索框
+    docsearchOptions: { // algolia 搜索配置
+      versionV3: false, // 目前有两个版本的 docsearch.js，V2.x 和 V3.x，此开关决定用哪一个版本的搜索框，根据申请到的参数版本决定，二者互不兼容，详情见 https://docsearch.algolia.com/
+      appId: 'xxxx', // V3.x 版本 docsearch 需要appId, V2.x 版不需要。
+      apiKey: 'xxxxxx',
+      indexName: 'xxx',
+
+    }
     showChinaMirror: true, // 是否展示国内镜像链接
     showLanguageSwitcher: true, // 用于定义是否展示语言切换
     showAntVProductsCard: true, // 是否展示 AntV 系列产品的卡片链接
@@ -101,6 +108,7 @@ module.exports = {
     themeSwitcher: 'g2', // 是否在demo页展示主题切换, 取值为'g2' | 'g2plot' 如果不设置则不展示主题切换工具
     showAPIDoc: true, // 是否在demo页展示API文档
     showExampleDemoTitle: true, // 有截图的是否要展示 title 名称
+
     mdPlayground: {
       // markdown 文档中的 playground 若干设置
       splitPaneMainSize: '62%',
@@ -165,28 +173,24 @@ import Companies from '@antv/gatsby-theme-antv/site/components/Companies';
 const Layout = () => {
   const features = [
     {
-      icon:
-        'https://gw.alipayobjects.com/zos/basement_prod/5dbaf094-c064-4a0d-9968-76020b9f1510.svg',
+      icon: 'https://gw.alipayobjects.com/zos/basement_prod/5dbaf094-c064-4a0d-9968-76020b9f1510.svg',
       title: 'xxxxx',
       description: 'xxxxxxxxxxxxxxxxxxxxxxxxx',
     },
     {
-      icon:
-        'https://gw.alipayobjects.com/zos/basement_prod/0a0371ab-6bed-41ad-a99b-87a5044ba11b.svg',
+      icon: 'https://gw.alipayobjects.com/zos/basement_prod/0a0371ab-6bed-41ad-a99b-87a5044ba11b.svg',
       title: 'xxxxx',
       description: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     },
     {
-      icon:
-        'https://gw.alipayobjects.com/zos/basement_prod/716d0bc0-e311-4b28-b79f-afdd16e8148e.svg',
+      icon: 'https://gw.alipayobjects.com/zos/basement_prod/716d0bc0-e311-4b28-b79f-afdd16e8148e.svg',
       title: 'xxxxx',
       description: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
     },
   ];
   const cases = [
     {
-      logo:
-        'https://gw.alipayobjects.com/mdn/rms_23b644/afts/img/A*2Ij9T76DyCcAAAAAAAAAAABkARQnAQ',
+      logo: 'https://gw.alipayobjects.com/mdn/rms_23b644/afts/img/A*2Ij9T76DyCcAAAAAAAAAAABkARQnAQ',
       title: '灯塔专业版',
       description:
         '深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金深入金融的基金',


### PR DESCRIPTION
新申请的 docsearch key包含 appId, 只适用于 v3.x 版本的docsearch.js, v2.x  版本 appId 可不填默认提供写死
![image](https://user-images.githubusercontent.com/10885578/163094399-57f4e1d0-8a5a-4b19-bc96-48fe62731bfa.png)
详情见 https://docsearch.algolia.com/
考虑到整栈升级成本，提供两种版本的组件配置选项，效果如下：
v2.x:
![v2](https://user-images.githubusercontent.com/10885578/163094766-1fae5f9f-54db-4da8-aecb-533d9b02484d.gif)

v3.x
![v](https://user-images.githubusercontent.com/10885578/163094864-a95446d4-23f2-446d-bfcb-f563effd6f08.gif)

（PS: 样式就这样叭，随便改改，摆烂了，又不是不能用🙃🙃🙃🙃）