### PR TITLE
fix: fix default demo error

### DIFF
--- a/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
@@ -210,7 +210,7 @@ insertCss(`;
   };
 
   useEffect(() => {
-    if (currentExample || !examples || !exampleSections?.examples.length) return;
+    if (currentExample || !examples || !exampleSections?.examples?.length) return;
 
     let defaultExample = exampleSections.examples[0];
     const pathName = location.pathname.split('/');

--- a/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
+++ b/@antv/gatsby-theme-antv/site/components/PlayGround.tsx
@@ -210,9 +210,9 @@ insertCss(`;
   };
 
   useEffect(() => {
-    if (currentExample || !examples) return;
+    if (currentExample || !examples || !exampleSections?.examples.length) return;
 
-    let defaultExample = examples[0];
+    let defaultExample = exampleSections.examples[0];
     const pathName = location.pathname.split('/');
     const dirname = pathName.slice(2).join('\\/');
     const fullname = `${pathName.slice(3).join('\\/')}\\/demo\\/${location.hash?.replace('#', '').replace('/', '\\/')}`;


### PR DESCRIPTION
问题的来源是G2Plot关于双轴图的一个demo链接打开错误
![图片](https://user-images.githubusercontent.com/30228406/185399364-2c45407a-772f-4ceb-b12b-a9d3d630a100.png)

点击demo会跳转到https://g2plot.antv.vision/zh/examples/dual-axes/dual-line
这个链接打开, 理论上应该是打开双轴图的, 实际打开的却是面积图. 对比了下其他的demo链接, 发现是少了哈希路由参数
正确的应该是https://g2plot.antv.vision/zh/examples/dual-axes/dual-line#dual-line

本来是想修改文档链接的, 但是我发现这种不带哈希的路由有好多地方在使用, 不止是G2Plot, 很多antv系列产品都在使用. 我怀疑最早的时候是支持不带哈希路由的, 不带哈希路由的情况下, 应该是默认读取这个类别的第一个demo才是. 而不是随便找个图表类型.