### PR TITLE
npm run start 项目运行报错

### DIFF
--- a/@antv/gatsby-theme-antv/gatsby-node.js
+++ b/@antv/gatsby-theme-antv/gatsby-node.js
@@ -222,7 +222,12 @@ exports.createPages = async ({ actions, graphql, reporter, store }) => {
     const source = fs.readFileSync(item.absolutePath, 'utf8');
     const { code } = transform(source, {
       filename: item.absolutePath,
-      presets: ['react', 'typescript', 'es2015', 'stage-3'],
+      presets: ['react', 'typescript', 'es2015', [
+        'stage-3', 
+        {
+          decoratorsLegacy: true,
+        }
+      ]],
       plugins: ['transform-modules-umd'],
       babelrc: false,
     });


### PR DESCRIPTION
当我通过 README 来创建项目并运行的时候，报 babel 错误。

```shell
$ yarn global add gatsby-cli
$ gatsby new mysite https://github.com/antvis/gatsby-starter-theme-antv
$ cd mysite
$ yarn start
```

> "@antv/gatsby-theme-antv" threw an error while running the createPages lifecycle: 
Error: [BABEL] /C:/Users/violetjack/github/G2-4/examples/bar/basic/demo/bsic.ts: The decorators plugin, when .version is '2018-09' or not specified, requires a 'decoratorsBeforeExport' option, whose value must be a boolean. (While pro cessing: "base3333$inherits")

查了源码发现是 @babel/standalone 中的 `stage-3` 这个 preset 里面用到了 @babel/plugin-proposal-decorators，它的配置引起了报错。

详见 [掘金文章](https://juejin.cn/post/7211064454573654073)